### PR TITLE
chore: project maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ pnpm-debug.log*
 # macOS-specific files
 .DS_Store
 
+# large media files
+public/assets/video/
+
 # ignore .astro directory
 .astro
 

--- a/src/content/blog/240219-web-workers-api.md
+++ b/src/content/blog/240219-web-workers-api.md
@@ -2,7 +2,7 @@
 author: Romain C.
 pubDatetime: 2024-02-19T13:00:00Z
 title: "Web Workers: When the Main Thread Needs a Break"
-slug: optimizing-react-performance
+slug: web-workers-api
 featured: false
 draft: false
 tags: ["javascript", "web-workers", "performance", "concurrency"]

--- a/src/content/blog/250224-huggingface-ai-agents-course-review.md
+++ b/src/content/blog/250224-huggingface-ai-agents-course-review.md
@@ -15,34 +15,17 @@ Hugging Face recently released the first unit of their AI Agents course. I wante
 
 ## What is an AI Agent?
 
-An AI Agent is essentially a system that combines an AI model (typically an LLM) with the ability to interact with its environment. Think of it like a digital assistant that can:
-
-- Understand natural language requests
-- Plan and reason about how to fulfill those requests
-- Take actions using tools to accomplish tasks
-- Learn from the results of those actions
+An AI Agent is essentially a system that combines an AI model (typically an LLM) with the ability to interact with its environment. Think of it like a digital assistant that can understand natural language requests, plan and reason about how to fulfill those requests, take actions using tools to accomplish tasks, and learn from the results of those actions.
 
 ## The Three Core Components
 
 The course introduced three fundamental components that make up an agent's workflow:
 
-1. **Thoughts**: The agent's internal reasoning process where it:
+1. **Thoughts**: The agent's internal reasoning process where it analyzes the current situation, plans the next steps, decides which actions to take, and uses the ReAct approach (Reasoning + Acting) for step-by-step planning.
 
-   - Analyzes the current situation
-   - Plans the next steps
-   - Decides which actions to take
-   - Uses the ReAct approach (Reasoning + Acting) for step-by-step planning
+2. **Actions**: How the agent interacts with its environment through tools (functions or APIs it can call), structured formats (usually JSON or code), and the "stop and parse" approach for reliable execution.
 
-2. **Actions**: How the agent interacts with its environment through:
-
-   - Tools (functions or APIs it can call)
-   - Structured formats (usually JSON or code)
-   - The "stop and parse" approach for reliable execution
-
-3. **Observations**: How the agent processes feedback by:
-   - Collecting results from actions
-   - Updating its understanding
-   - Adapting its strategy based on outcomes
+3. **Observations**: How the agent processes feedback by collecting results from actions, updating its understanding, and adapting its strategy based on outcomes.
 
 ## The Role of LLMs
 
@@ -73,10 +56,6 @@ The course demonstrated several practical applications:
 
 ## Conclusion
 
-This new Hugging Face course demystifies AI agents. Rather than being magical black boxes, they're structured systems that combine:
-
-- LLMs for reasoning
-- Tools for taking action
-- A clear workflow for processing and responding
+This new Hugging Face course demystifies AI agents. Rather than being magical black boxes, they're structured systems that combine LLMs for reasoning, tools for taking action, and a clear workflow for processing and responding.
 
 If you're interested in AI agents, I highly recommend checking out [the course](https://hf.co/learn/agents-course) yourself, or even the [source code](https://github.com/huggingface/agents-course) on GitHub.

--- a/src/pages/posts/[slug]/index.astro
+++ b/src/pages/posts/[slug]/index.astro
@@ -11,7 +11,7 @@ export async function getStaticPaths() {
   const posts = await getCollection("blog", ({ data }) => !data.draft);
 
   const postResult = posts.map(post => ({
-    params: { slug: post.slug },
+    params: { slug: post.slug || post.id.replace(/^blog\//, "") },
     props: { post },
   }));
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,8 @@
   "compilerOptions": {
     "baseUrl": "src",
     "jsx": "react-jsx",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
     "paths": {
       "@assets/*": ["assets/*"],
       "@config": ["config.ts"],


### PR DESCRIPTION
Changements de maintenance sur le repo :

- **.gitignore** → ignore `public/assets/video/` (fichier binaire de 68MB déjà dans l'historique git)
- **tsconfig.json** → ajoute `moduleResolution: bundler` et `skipLibCheck: true` pour compatibilité future
- **posts/[slug]/index.astro** → fallback sur `post.id` quand `post.slug` n'est pas défini dans le frontmatter
- **web-workers-api** → corrige un slug dupliqué (`optimizing-react-performance` → `web-workers-api`)
- **huggingface-ai-agents** → légère humanisation (listes imbriquées réduites)

Note : La mise à jour majeure d'Astro (4 → 5/6) a été tentée mais requerrait une migration complète du Content Layer. Gardé Astro 4 pour l'instant.