### PR TITLE
feat: polish portfolio work presentation

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -44,9 +44,7 @@ const { activeNav } = Astro.props;
             </a>
           </li>
           <li>
-            <a href="/tags/" class:list={[{ active: activeNav === "tags" }]}>
-              Tags
-            </a>
+            <a href="mailto:contact@romaincoupey.com">Contact</a>
           </li>
           <li>
             <LinkButton

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -12,7 +12,8 @@ export default function ProjectCard({
   frontmatter,
   secHeading = true,
 }: Props) {
-  const { title, tags, description, ogImage } = frontmatter;
+  const { title, tags, description, ogImage, impact, role, type, status } =
+    frontmatter;
 
   const headerProps = {
     style: { viewTransitionName: slugifyStr(title) },
@@ -21,6 +22,7 @@ export default function ProjectCard({
   };
 
   const imageUrl = typeof ogImage === "string" ? ogImage : ogImage?.src;
+  const meta = [type, role, status].filter(Boolean).join(" · ");
 
   return (
     <article className="group py-8 -mx-4 px-4 rounded-sm transition-colors duration-300 hover:bg-skin-card">
@@ -34,11 +36,26 @@ export default function ProjectCard({
             />
           </div>
         )}
-        <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-skin-base/50 mb-4">
+        <div className="mb-4 flex flex-wrap gap-2">
           {tags.slice(0, 4).map(tag => (
-            <span key={tag}>{tag}</span>
+            <span
+              key={tag}
+              className="rounded border border-skin-line px-2 py-0.5 text-xs text-skin-base/60 transition-colors group-hover:border-skin-accent/50 group-hover:text-skin-accent"
+            >
+              {tag}
+            </span>
           ))}
+          {tags.length > 4 && (
+            <span className="px-1 py-0.5 text-xs text-skin-base/40">
+              +{tags.length - 4}
+            </span>
+          )}
         </div>
+        {meta && (
+          <div className="mb-2 text-sm font-medium text-skin-base/50">
+            {meta}
+          </div>
+        )}
         {secHeading ? (
           <h2 {...headerProps}>{title}</h2>
         ) : (
@@ -47,6 +64,11 @@ export default function ProjectCard({
         <p className="mt-2 text-skin-base/70 leading-relaxed max-w-2xl">
           {description}
         </p>
+        {impact && (
+          <p className="mt-3 max-w-2xl text-sm font-medium text-skin-base/80">
+            {impact}
+          </p>
+        )}
       </a>
     </article>
   );

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -46,6 +46,10 @@ const projects = defineCollection({
       slug: z.string().optional(),
       featured: z.boolean().optional(),
       draft: z.boolean().optional(),
+      role: z.string().optional(),
+      type: z.string().optional(),
+      status: z.string().optional(),
+      impact: z.string().optional(),
       tags: z.array(z.string()).default(["others"]),
       ogImage: image()
         .refine(img => img.width >= 1200 && img.height >= 630, {

--- a/src/content/projects/autonomous-pea-research-pipeline.md
+++ b/src/content/projects/autonomous-pea-research-pipeline.md
@@ -4,6 +4,10 @@ description: "A Hermes Agent research loop for European equities that treats eve
 pubDatetime: 2026-05-10T17:35:00Z
 tags: ["python", "ai", "investing", "automation", "dashboard"]
 featured: true
+type: "Research system"
+role: "Solo builder"
+status: "Exploratory"
+impact: "Turns agent output into evidence: backtests, diagnostics, refusal points, and a pre-rebalance gate before action."
 url: ""
 repository: ""
 ogImage: "/assets/images/project-thumbs/pea-agent-log-preview.png"

--- a/src/content/projects/emili-3d.md
+++ b/src/content/projects/emili-3d.md
@@ -4,7 +4,11 @@ description: "A browser-based 3D platform for Imerys' lithium mining project, bu
 pubDatetime: 2024-03-11T15:30:00Z
 tags: ["threejs", "mapbox", "javascript"]
 featured: true
-url: "https://emili3d.imerys.com"
+type: "3D GIS public interface"
+role: "Frontend engineer"
+status: "Client work"
+impact: "Makes a complex industrial site easier to explore during public debate through map-based 3D context."
+url: "https://emili.imerys.com/visite-3d/"
 ogImage: "/assets/images/project-thumbs/emili.jpg"
 ---
 

--- a/src/content/projects/en-minutes.md
+++ b/src/content/projects/en-minutes.md
@@ -4,6 +4,10 @@ description: "A bilingual data visualization app that turns French prices into m
 pubDatetime: 2026-03-13T09:00:00Z
 tags: ["react", "typescript", "data-visualization", "economics"]
 featured: true
+type: "Public data app"
+role: "Solo builder"
+status: "Live"
+impact: "Reframes French purchasing power in minutes of work, with salary references and methodology choices visible."
 url: "https://enminutes.fr"
 repository: "https://github.com/Ngopimas/enminutes"
 ogImage: "/assets/images/project-thumbs/en-minutes.jpg"

--- a/src/content/projects/geoportal.md
+++ b/src/content/projects/geoportal.md
@@ -4,7 +4,11 @@ description: "A cloud data science platform for geoscientists, focused on workfl
 pubDatetime: 2023-02-11T15:30:00Z
 tags: ["react", "cloud", "data-science", "python", "automation", "3d"]
 featured: true
-url: "https://deeplime.io/products#geoportal"
+type: "Data platform"
+role: "Fullstack engineer"
+status: "Client work"
+impact: "Gives geoscientists a browser workspace for resource estimation, automation, and 3D geological context."
+url: "https://www.deeplime.io/geoportal/"
 ogImage: "/assets/images/project-thumbs/geoportal.jpg"
 ---
 

--- a/src/content/projects/omaha-insights.md
+++ b/src/content/projects/omaha-insights.md
@@ -4,6 +4,10 @@ description: "A finance analytics web app for KPI monitoring, peer comparison, v
 pubDatetime: 2025-06-10T09:00:00Z
 tags: ["nextjs", "typescript", "tailwind", "recharts", "gcp"]
 featured: true
+type: "Finance product"
+role: "Lead developer"
+status: "Live"
+impact: "Makes KPI monitoring, peer comparison, valuation, and screening workflows easier to inspect and trust."
 url: "https://omaha-insights.com"
 ogImage: "/assets/images/project-thumbs/omaha.jpg"
 ---

--- a/src/content/projects/onecode.md
+++ b/src/content/projects/onecode.md
@@ -4,6 +4,10 @@ description: "A cloud platform for deploying Python applications from the OneCod
 pubDatetime: 2024-07-11T15:30:00Z
 tags: ["nextjs", "aws", "typescript", "python", "serverless"]
 featured: true
+type: "Cloud platform"
+role: "Lead developer"
+status: "Live"
+impact: "Turns Python workflows into deployable applications with workspace boundaries, permissions, logs, and cleanup."
 url: "https://www.onecode.rocks"
 repository: "https://github.com/deeplime-io/onecode"
 ogImage: "/assets/images/project-thumbs/onecode-cloud.jpg"

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -62,7 +62,9 @@ const currentPostIndex = allPosts.findIndex(a => a.slug === getEntrySlug(post));
 
 const prevPost = currentPostIndex !== 0 ? allPosts[currentPostIndex - 1] : null;
 const nextPost =
-  currentPostIndex !== allPosts.length ? allPosts[currentPostIndex + 1] : null;
+  currentPostIndex !== allPosts.length - 1
+    ? allPosts[currentPostIndex + 1]
+    : null;
 ---
 
 <Layout {...layoutProps}>
@@ -94,7 +96,7 @@ const nextPost =
       <Content />
     </article>
 
-    <ul class="my-8 flex gap-2 wrap">
+    <ul class="my-8 flex flex-wrap gap-2">
       {tags.map(tag => <Tag tag={slugifyStr(tag)} tagName={tag} />)}
     </ul>
 

--- a/src/layouts/ProjectDetails.astro
+++ b/src/layouts/ProjectDetails.astro
@@ -2,6 +2,7 @@
 import Layout from "@layouts/Layout.astro";
 import Header from "@components/Header.astro";
 import Footer from "@components/Footer.astro";
+import Tag from "@components/Tag.astro";
 import { type CollectionEntry, render } from "astro:content";
 import { slugifyStr } from "@utils/slugify";
 import ShareLinks from "@components/ShareLinks.astro";
@@ -26,6 +27,10 @@ const {
   tags,
   repository,
   url,
+  role,
+  type,
+  status,
+  impact,
 } = post.data;
 
 const { Content } = await render(post);
@@ -58,7 +63,10 @@ const currentPostIndex = allPosts.findIndex(a => a.slug === getEntrySlug(post));
 
 const prevPost = currentPostIndex !== 0 ? allPosts[currentPostIndex - 1] : null;
 const nextPost =
-  currentPostIndex !== allPosts.length ? allPosts[currentPostIndex + 1] : null;
+  currentPostIndex !== allPosts.length - 1
+    ? allPosts[currentPostIndex + 1]
+    : null;
+const projectMeta = [type, role, status].filter(Boolean);
 ---
 
 <Layout {...layoutProps}>
@@ -78,19 +86,51 @@ const nextPost =
       {title}
     </h1>
 
-    <ul class="my-5 flex flex-wrap gap-x-4 gap-y-1 text-sm text-skin-base/50">
-      {tags.map(tag => <li>{tag}</li>)}
+    <ul class="my-5 flex flex-wrap gap-2">
+      {tags.map(tag => <Tag tag={slugifyStr(tag)} tagName={tag} />)}
     </ul>
+
+    {
+      (projectMeta.length > 0 || impact) && (
+        <div class="my-6 rounded-sm border border-skin-line p-5 text-sm">
+          {projectMeta.length > 0 && (
+            <dl class="grid gap-4 sm:grid-cols-3">
+              {type && (
+                <div>
+                  <dt class="text-skin-base/40">Type</dt>
+                  <dd class="mt-1 font-medium text-skin-base">{type}</dd>
+                </div>
+              )}
+              {role && (
+                <div>
+                  <dt class="text-skin-base/40">Role</dt>
+                  <dd class="mt-1 font-medium text-skin-base">{role}</dd>
+                </div>
+              )}
+              {status && (
+                <div>
+                  <dt class="text-skin-base/40">Status</dt>
+                  <dd class="mt-1 font-medium text-skin-base">{status}</dd>
+                </div>
+              )}
+            </dl>
+          )}
+          {impact && <p class="mt-4 text-skin-base/75">{impact}</p>}
+        </div>
+      )
+    }
 
     <div class="my-2 grid gap-2 text-sm">
       {
         url && (
           <a
             title={url}
-            class="overflow-hidden text-ellipsis whitespace-nowrap hover:text-skin-accent hover:opacity-75"
+            class="overflow-hidden text-ellipsis whitespace-nowrap rounded-sm border border-skin-line px-3 py-2 hover:border-skin-accent hover:text-skin-accent"
             href={url}
+            target="_blank"
+            rel="noopener noreferrer"
           >
-            <span class="underline underline-offset-4">Live</span>: {url}
+            Live: {url}
           </a>
         )
       }
@@ -98,11 +138,12 @@ const nextPost =
         repository && (
           <a
             title={repository}
-            class="overflow-hidden text-ellipsis whitespace-nowrap hover:text-skin-accent hover:opacity-75"
+            class="overflow-hidden text-ellipsis whitespace-nowrap rounded-sm border border-skin-line px-3 py-2 hover:border-skin-accent hover:text-skin-accent"
             href={repository}
+            target="_blank"
+            rel="noopener noreferrer"
           >
-            <span class="underline underline-offset-4">Repository</span>:{" "}
-            {repository}
+            Repository: {repository}
           </a>
         )
       }
@@ -138,7 +179,7 @@ const nextPost =
           >
             <span class="flex-none">←</span>
             <div>
-              <span>Previous Post</span>
+              <span>Previous project</span>
               <div class="text-sm text-skin-accent/85">{prevPost.title}</div>
             </div>
           </a>
@@ -151,7 +192,7 @@ const nextPost =
             class="flex w-full justify-end gap-1 text-right hover:opacity-75 sm:col-start-2"
           >
             <div>
-              <span>Next Post</span>
+              <span>Next project</span>
               <div class="text-sm text-skin-accent/85">{nextPost.title}</div>
             </div>
             <span class="flex-none">→</span>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -65,16 +65,14 @@ const socialCount = SOCIALS.filter(social => social.active).length;
     {
       featuredProjects.length > 0 && (
         <section class="mx-auto max-w-4xl py-16">
-          <div class="mb-10 flex items-baseline justify-between">
+          <div class="mb-10">
             <h2 class="font-display text-3xl font-medium tracking-tight">
               Selected Work
             </h2>
-            <LinkButton
-              href="/projects/"
-              className="text-sm text-skin-base/50 hover:text-skin-accent transition-colors"
-            >
-              View all
-            </LinkButton>
+            <p class="mt-3 max-w-2xl text-skin-base/60">
+              Research tooling, finance dashboards, data visualizations, and
+              production web applications.
+            </p>
           </div>
           <div class="divide-y divide-skin-line">
             {featuredProjects.map(
@@ -88,6 +86,14 @@ const socialCount = SOCIALS.filter(social => social.active).length;
                 )
             )}
           </div>
+          <div class="mt-8">
+            <LinkButton
+              href="/projects/"
+              className="text-sm font-medium text-skin-base/60 hover:text-skin-accent transition-colors"
+            >
+              View all work →
+            </LinkButton>
+          </div>
         </section>
       )
     }
@@ -95,16 +101,14 @@ const socialCount = SOCIALS.filter(social => social.active).length;
     {
       sortedPosts.length > 0 && (
         <section class="mx-auto max-w-4xl py-16">
-          <div class="mb-10 flex items-baseline justify-between">
+          <div class="mb-10">
             <h2 class="font-display text-3xl font-medium tracking-tight">
               Writing
             </h2>
-            <LinkButton
-              href="/posts/"
-              className="text-sm text-skin-base/50 hover:text-skin-accent transition-colors"
-            >
-              View all
-            </LinkButton>
+            <p class="mt-3 max-w-2xl text-skin-base/60">
+              Field notes from building AI-assisted research systems,
+              dashboards, and production web apps.
+            </p>
           </div>
           <div class="divide-y divide-skin-line">
             {sortedPosts.map(
@@ -119,9 +123,43 @@ const socialCount = SOCIALS.filter(social => social.active).length;
                 )
             )}
           </div>
+          <div class="mt-8">
+            <LinkButton
+              href="/posts/"
+              className="text-sm font-medium text-skin-base/60 hover:text-skin-accent transition-colors"
+            >
+              Read all writing →
+            </LinkButton>
+          </div>
         </section>
       )
     }
+
+    <section class="mx-auto max-w-4xl py-16">
+      <div class="rounded-sm border border-skin-line p-6 sm:p-8">
+        <p class="max-w-2xl text-lg text-skin-base">
+          Interested in research tooling, finance dashboards, or interfaces that
+          make complex systems easier to trust?
+        </p>
+        <div class="mt-5 flex flex-wrap gap-4 text-sm font-medium">
+          <LinkButton href="mailto:contact@romaincoupey.com">Email</LinkButton>
+          <LinkButton
+            href="https://www.linkedin.com/in/romain-coupey/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            LinkedIn
+          </LinkButton>
+          <LinkButton
+            href="https://github.com/Ngopimas/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            GitHub
+          </LinkButton>
+        </div>
+      </div>
+    </section>
   </main>
 
   <Footer />


### PR DESCRIPTION
## Summary
- replace the homepage section-header View all links with bottom CTAs and add a final contact block
- simplify primary nav by replacing Tags with Contact
- standardize project tag styling and add role/type/status/impact metadata to featured work
- polish project detail pages with shared tag pills, metadata panel, external-link buttons, and project-specific prev/next labels
- fix post/project prev-next edge cases and post tag wrapping

## Verification
- npm run format:check
- npm run build
- scanned generated HTML for /projects/undefined/, /posts/undefined/, NaN, and Infinity
- verified rendered strings for homepage CTAs and corrected OneCode, GeoPortal, and EMILI metadata

## Notes
- Changed EMILI type to "3D GIS public interface" rather than "3D in SIG public interface" because it reads more naturally in English.
