### PR TITLE
Polish portfolio search and topic discovery

### DIFF
--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -1,17 +1,34 @@
 import Fuse from "fuse.js";
 import { useEffect, useRef, useState, useMemo, type FormEvent } from "react";
 import Card from "@components/Card";
+import ProjectCard from "@components/ProjectCard";
 import type { CollectionEntry } from "astro:content";
 
-export type SearchItem = {
-  title: string;
-  description: string;
-  data: CollectionEntry<"blog">["data"];
-  slug: string;
+export type SearchTopic = {
+  tag: string;
+  tagName: string;
+  count: number;
 };
+
+export type SearchItem =
+  | {
+      kind: "post";
+      title: string;
+      description: string;
+      data: CollectionEntry<"blog">["data"];
+      slug: string;
+    }
+  | {
+      kind: "project";
+      title: string;
+      description: string;
+      data: CollectionEntry<"projects">["data"];
+      slug: string;
+    };
 
 interface Props {
   searchList: SearchItem[];
+  topics: SearchTopic[];
 }
 
 interface SearchResult {
@@ -19,7 +36,7 @@ interface SearchResult {
   refIndex: number;
 }
 
-export default function SearchBar({ searchList }: Props) {
+export default function SearchBar({ searchList, topics }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [inputVal, setInputVal] = useState("");
   const [searchResults, setSearchResults] = useState<SearchResult[] | null>(
@@ -33,10 +50,18 @@ export default function SearchBar({ searchList }: Props) {
   const fuse = useMemo(
     () =>
       new Fuse(searchList, {
-        keys: ["title", "description"],
+        keys: [
+          "title",
+          "description",
+          "data.tags",
+          "data.role",
+          "data.type",
+          "data.status",
+          "data.impact",
+        ],
         includeMatches: true,
         minMatchCharLength: 2,
-        threshold: 0.5,
+        threshold: 0.45,
       }),
     [searchList]
   );
@@ -71,14 +96,17 @@ export default function SearchBar({ searchList }: Props) {
     } else {
       history.replaceState(history.state, "", window.location.pathname);
     }
-  }, [inputVal]);
+  }, [inputVal, fuse]);
 
   useEffect(() => {
     // focus on text input when search bar is displayed
     if (inputRef.current) {
       inputRef.current.focus();
     }
-  }, [inputVal]);
+  }, []);
+
+  const hasQuery = inputVal.length > 1;
+  const hasNoResults = hasQuery && searchResults?.length === 0;
 
   return (
     <>
@@ -91,18 +119,17 @@ export default function SearchBar({ searchList }: Props) {
         </span>
         <input
           className="block w-full rounded border border-skin-line/40 bg-skin-card py-3 pl-10 pr-3 placeholder:text-skin-base/30 focus:border-skin-accent focus:outline-none"
-          placeholder="Search articles..."
+          placeholder="Search work and writing..."
           type="text"
           name="search"
           value={inputVal}
           onChange={handleChange}
           autoComplete="off"
-          // autoFocus
           ref={inputRef}
         />
       </label>
 
-      {inputVal.length > 1 && (
+      {hasQuery && (
         <div className="mt-8 text-sm text-skin-base/50">
           {searchResults?.length}{" "}
           {searchResults?.length === 1 ? "result" : "results"}
@@ -110,15 +137,52 @@ export default function SearchBar({ searchList }: Props) {
       )}
 
       <ul>
-        {searchResults &&
-          searchResults.map(({ item, refIndex }) => (
-            <Card
-              href={`/posts/${item.slug}/`}
-              frontmatter={item.data}
-              key={`${refIndex}-${item.slug}`}
-            />
-          ))}
+        {searchResults?.map(({ item, refIndex }) => (
+          <li key={`${refIndex}-${item.kind}-${item.slug}`}>
+            {item.kind === "post" ? (
+              <Card href={`/posts/${item.slug}/`} frontmatter={item.data} />
+            ) : (
+              <ProjectCard
+                href={`/projects/${item.slug}/`}
+                frontmatter={item.data}
+              />
+            )}
+          </li>
+        ))}
       </ul>
+
+      {(!hasQuery || hasNoResults) && topics.length > 0 && (
+        <section className="mt-12 rounded-sm border border-skin-line p-5">
+          <div className="mb-4">
+            <h2 className="font-display text-xl font-medium tracking-tight">
+              Browse topics
+            </h2>
+            <p className="mt-2 text-sm text-skin-base/60">
+              Use topics as a starting point when you do not have a specific
+              query.
+            </p>
+          </div>
+          <ul className="flex flex-wrap gap-2">
+            {topics.map(({ tag, tagName, count }) => (
+              <li key={tag}>
+                <a
+                  href={`/tags/${tag}/`}
+                  className="inline-flex items-center gap-1 rounded border border-skin-line px-2 py-1 text-xs text-skin-base/60 transition-colors hover:border-skin-accent hover:text-skin-accent"
+                >
+                  <span>{tagName}</span>
+                  <span className="text-skin-base/35">{count}</span>
+                </a>
+              </li>
+            ))}
+          </ul>
+          <a
+            href="/tags/"
+            className="mt-5 inline-block text-sm font-medium text-skin-base/60 transition-colors hover:text-skin-accent"
+          >
+            View all topics →
+          </a>
+        </section>
+      )}
     </>
   );
 }

--- a/src/content/projects/block-model.md
+++ b/src/content/projects/block-model.md
@@ -4,6 +4,10 @@ description: "A browser-based 3D tool for exploring mining block model data with
 pubDatetime: 2022-07-11T15:30:00Z
 tags: ["threejs", "react", "typescript"]
 featured: false
+type: "3D visualization"
+role: "Solo Builder"
+status: "Client work"
+impact: "Made dense geological block model data explorable in the browser through slicing, property coloring, and interactive 3D controls."
 url: "https://ngopimas.github.io/POC_BM_3D/"
 ogImage: "/assets/images/project-thumbs/block-model.jpg"
 # repository: "https://github.com/Ngopimas/POC_BM_3D"

--- a/src/content/projects/profile-minimal.md
+++ b/src/content/projects/profile-minimal.md
@@ -4,6 +4,10 @@ description: "A fast Astro portfolio focused on writing, project pages, search, 
 pubDatetime: 2025-02-11T15:30:00Z
 tags: ["astro", "typescript", "tailwind", "react"]
 featured: false
+type: "Portfolio system"
+role: "Solo Builder"
+status: "Active"
+impact: "Keeps project pages, writing, search, and static deployment simple enough to maintain without hiding the work behind a heavy CMS."
 url: "https://romaincoupey.com"
 repository: "https://github.com/Ngopimas/profile-minimal"
 ogImage: "/assets/images/project-thumbs/profile-minimal.svg"

--- a/src/content/projects/startbridge.md
+++ b/src/content/projects/startbridge.md
@@ -4,6 +4,10 @@ description: "A marketplace platform connecting innovators and stakeholders, wit
 pubDatetime: 2022-07-01T09:00:00Z
 tags: ["react", "reactquery", "material-ui"]
 featured: false
+type: "Marketplace platform"
+role: "Frontend developer"
+status: "Client work"
+impact: "Turned evolving marketplace and feedback workflows into React interfaces for an early-stage innovation platform."
 url: "https://startbridge.io"
 ogImage: "/assets/images/project-thumbs/startbridge.jpg"
 ---

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -68,7 +68,7 @@ const nextPost =
 ---
 
 <Layout {...layoutProps}>
-  <Header />
+  <Header activeNav="posts" />
 
   <div class="mx-auto flex w-full max-w-4xl justify-start px-6">
     <button
@@ -116,7 +116,7 @@ const nextPost =
 
     <hr class="my-6 border-dashed" />
 
-    <!-- Previous/Next Post Buttons -->
+    <!-- Previous/next article buttons -->
     <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
       {
         prevPost && (
@@ -126,7 +126,7 @@ const nextPost =
           >
             <span class="flex-none">←</span>
             <div>
-              <span>Previous Post</span>
+              <span>Previous article</span>
               <div class="text-sm text-skin-accent/85">{prevPost.title}</div>
             </div>
           </a>
@@ -139,7 +139,7 @@ const nextPost =
             class="flex w-full justify-end gap-1 text-right hover:opacity-75 sm:col-start-2"
           >
             <div>
-              <span>Next Post</span>
+              <span>Next article</span>
               <div class="text-sm text-skin-accent/85">{nextPost.title}</div>
             </div>
             <span class="flex-none">→</span>

--- a/src/layouts/ProjectDetails.astro
+++ b/src/layouts/ProjectDetails.astro
@@ -70,7 +70,7 @@ const projectMeta = [type, role, status].filter(Boolean);
 ---
 
 <Layout {...layoutProps}>
-  <Header />
+  <Header activeNav="projects" />
 
   <div class="mx-auto flex w-full max-w-4xl justify-start px-6">
     <button
@@ -169,7 +169,7 @@ const projectMeta = [type, role, status].filter(Boolean);
 
     <hr class="my-6 border-dashed" />
 
-    <!-- Previous/Next Post Buttons -->
+    <!-- Previous/next project buttons -->
     <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
       {
         prevPost && (

--- a/src/layouts/Projects.astro
+++ b/src/layouts/Projects.astro
@@ -19,7 +19,10 @@ const { page } = Astro.props;
 
 <Layout title={`Projects | ${SITE.title}`}>
   <Header activeNav="projects" />
-  <Main pageTitle="Work" pageDesc="Systems, applications, and experiments.">
+  <Main
+    pageTitle="Work"
+    pageDesc="AI systems, autonomous research tooling, data visualizations, and production web applications."
+  >
     <ul class="divide-y divide-skin-line">
       {
         page.data.map(project => (

--- a/src/layouts/TagPosts.astro
+++ b/src/layouts/TagPosts.astro
@@ -22,9 +22,9 @@ const { page, tag, tagName } = Astro.props;
 <Layout title={`${tagName} | ${SITE.title}`}>
   <Header activeNav="tags" />
   <Main
-    pageTitle={[`Tag:`, `${tagName}`]}
+    pageTitle={[`Topic:`, `${tagName}`]}
     titleTransition={tag}
-    pageDesc={`Articles tagged "${tagName}".`}
+    pageDesc={`Articles about "${tagName}".`}
   >
     <ul class="divide-y divide-skin-line">
       {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -70,7 +70,7 @@ const socialCount = SOCIALS.filter(social => social.active).length;
               Selected Work
             </h2>
             <p class="mt-3 max-w-2xl text-skin-base/60">
-              Research tooling, finance dashboards, data visualizations, and
+              AI systems, autonomous research tooling, data visualizations, and
               production web applications.
             </p>
           </div>
@@ -134,32 +134,6 @@ const socialCount = SOCIALS.filter(social => social.active).length;
         </section>
       )
     }
-
-    <section class="mx-auto max-w-4xl py-16">
-      <div class="rounded-sm border border-skin-line p-6 sm:p-8">
-        <p class="max-w-2xl text-lg text-skin-base">
-          Interested in research tooling, finance dashboards, or interfaces that
-          make complex systems easier to trust?
-        </p>
-        <div class="mt-5 flex flex-wrap gap-4 text-sm font-medium">
-          <LinkButton href="mailto:contact@romaincoupey.com">Email</LinkButton>
-          <LinkButton
-            href="https://www.linkedin.com/in/romain-coupey/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            LinkedIn
-          </LinkButton>
-          <LinkButton
-            href="https://github.com/Ngopimas/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            GitHub
-          </LinkButton>
-        </div>
-      </div>
-    </section>
   </main>
 
   <Footer />

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -8,24 +8,58 @@ import Footer from "@components/Footer.astro";
 import SearchBar from "@components/Search";
 import getSortedPosts from "@utils/getSortedPosts";
 import getEntrySlug from "@utils/getEntrySlug";
+import { slugifyStr } from "@utils/slugify";
 
-// Retrieve all published articles
 const posts = await getCollection("blog", ({ data }) => !data.draft);
+const projects = await getCollection("projects", ({ data }) => !data.draft);
 const sortedPosts = getSortedPosts(posts);
+const sortedProjects = getSortedPosts(projects);
 
-// List of items to search in
-const searchList = sortedPosts.map(post => ({
+const postResults = sortedPosts.map(post => ({
+  kind: "post" as const,
   title: post.data.title,
   description: post.data.description,
   data: post.data,
   slug: getEntrySlug(post),
 }));
+
+const projectResults = sortedProjects.map(project => ({
+  kind: "project" as const,
+  title: project.data.title,
+  description: project.data.description,
+  data: project.data,
+  slug: getEntrySlug(project),
+}));
+
+const searchList = [...projectResults, ...postResults];
+
+const topicCounts = new Map<
+  string,
+  { tag: string; tagName: string; count: number }
+>();
+for (const post of posts) {
+  for (const tagName of post.data.tags) {
+    const tag = slugifyStr(tagName);
+    const existing = topicCounts.get(tag);
+    topicCounts.set(tag, {
+      tag,
+      tagName: existing?.tagName ?? tagName,
+      count: (existing?.count ?? 0) + 1,
+    });
+  }
+}
+
+const topics = [...topicCounts.values()]
+  .sort(
+    (tagA, tagB) => tagB.count - tagA.count || tagA.tag.localeCompare(tagB.tag)
+  )
+  .slice(0, 28);
 ---
 
 <Layout title={`Search | ${SITE.title}`}>
   <Header activeNav="search" />
-  <Main pageTitle="Search" pageDesc="Find articles by keyword.">
-    <SearchBar client:load searchList={searchList} />
+  <Main pageTitle="Search" pageDesc="Find work, articles, and topics.">
+    <SearchBar client:load searchList={searchList} topics={topics} />
   </Main>
   <Footer />
 </Layout>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -13,9 +13,9 @@ const posts = await getCollection("blog");
 let tags = getUniqueTags(posts);
 ---
 
-<Layout title={`Tags | ${SITE.title}`}>
+<Layout title={`Topics | ${SITE.title}`}>
   <Header activeNav="tags" />
-  <Main pageTitle="Tags" pageDesc="Browse by topic.">
+  <Main pageTitle="Topics" pageDesc="Browse writing by topic.">
     <ul>
       {tags.map(({ tag, tagName }) => <Tag {tag} {tagName} size="lg" />)}
     </ul>


### PR DESCRIPTION
## Summary
- Expand search to cover both Work and Writing, with project cards in results
- Move topic discovery into the Search page with topic pills and a View all topics path
- Rename visible tag language to Topics and clean article/project detail labels
- Add missing project metadata for older work cards and simplify homepage contact duplication

## Verification
- npm run format:check
- npm run build
- Rendered regression scan: no undefined post/project links, no stale Post labels, no stale search placeholder, no NaN/Infinity in HTML
- Preview smoke checks returned 200 for /, /projects/, /search/, /tags/, /projects/profile-minimal/, /posts/web-workers-api/