### PR TITLE
docs: add GitHub from first principles series

### DIFF
--- a/public/assets/images/posts/git-push-does-not-upload-your-project/push-moves-refs.svg
+++ b/public/assets/images/posts/git-push-does-not-upload-your-project/push-moves-refs.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+<title>Git push moves references</title>
+<desc>A push sends missing Git objects and asks the remote to move a branch reference.</desc>
+<rect width="1200" height="630" fill="#0f172a"/>
+<rect x="70" y="70" width="1060" height="490" rx="28" fill="#111827" stroke="#334155" stroke-width="2"/>
+<text x="95" y="125" class="label">git push does not upload your project</text>
+<rect x="125" y="220" width="330" height="230" rx="20" class="box"/>
+<text x="165" y="270" class="label">local</text>
+<circle cx="205" cy="345" r="24" fill="#38bdf8"/><circle cx="285" cy="345" r="24" fill="#38bdf8"/><circle cx="365" cy="345" r="24" fill="#38bdf8"/>
+<path d="M229 345 H261 M309 345 H341" class="dimline"/>
+<text x="167" y="405" class="small">main -&gt; c3</text>
+<rect x="745" y="220" width="330" height="230" rx="20" class="box"/>
+<text x="785" y="270" class="label">remote</text>
+<circle cx="825" cy="345" r="24" fill="#38bdf8"/><circle cx="905" cy="345" r="24" fill="#38bdf8"/>
+<path d="M849 345 H881" class="dimline"/>
+<text x="787" y="405" class="small">main -&gt; c2</text>
+<path d="M470 335 H720" class="line"/>
+<text x="500" y="306" class="small">send c3, move main</text>
+<style>
+.label { font: 700 30px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #e5e7eb; }
+.small { font: 500 22px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #94a3b8; }
+.tiny { font: 500 18px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #64748b; }
+.box { fill: #1e293b; stroke: #475569; stroke-width: 2; }
+.good { fill: #064e3b; stroke: #10b981; stroke-width: 2; }
+.warn { fill: #422006; stroke: #f59e0b; stroke-width: 2; }
+.bad { fill: #450a0a; stroke: #ef4444; stroke-width: 2; }
+.line { stroke: #38bdf8; stroke-width: 5; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+.dimline { stroke: #475569; stroke-width: 3; fill: none; stroke-linecap: round; }
+</style>
+</svg>

--- a/public/assets/images/posts/github-is-just-a-remote-until-it-isnt/tiny-git-remote.svg
+++ b/public/assets/images/posts/github-is-just-a-remote-until-it-isnt/tiny-git-remote.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+<title>A tiny Git remote over SSH</title>
+<desc>A laptop connects over SSH to a Linux box that stores a bare Git repository.</desc>
+<rect width="1200" height="630" fill="#0f172a"/>
+<rect x="70" y="70" width="1060" height="490" rx="28" fill="#111827" stroke="#334155" stroke-width="2"/>
+<text x="95" y="125" class="label">GitHub is just a remote until it isn't</text>
+<rect x="120" y="250" width="230" height="130" rx="18" class="box"/>
+<text x="160" y="305" class="label">laptop</text>
+<text x="150" y="342" class="small">working tree</text>
+<path d="M370 315 H575" class="line"/>
+<text x="410" y="292" class="small">ssh + git push</text>
+<rect x="605" y="220" width="230" height="190" rx="18" class="box"/>
+<text x="650" y="280" class="label">linux box</text>
+<rect x="665" y="315" width="110" height="55" rx="10" class="good"/>
+<text x="690" y="350" class="small">repo.git</text>
+<path d="M850 315 H1035" class="dimline"/>
+<text x="880" y="292" class="small">no website yet</text>
+<style>
+.label { font: 700 30px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #e5e7eb; }
+.small { font: 500 22px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #94a3b8; }
+.tiny { font: 500 18px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #64748b; }
+.box { fill: #1e293b; stroke: #475569; stroke-width: 2; }
+.good { fill: #064e3b; stroke: #10b981; stroke-width: 2; }
+.warn { fill: #422006; stroke: #f59e0b; stroke-width: 2; }
+.bad { fill: #450a0a; stroke: #ef4444; stroke-width: 2; }
+.line { stroke: #38bdf8; stroke-width: 5; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+.dimline { stroke: #475569; stroke-width: 3; fill: none; stroke-linecap: round; }
+</style>
+</svg>

--- a/public/assets/images/posts/pull-requests-are-not-git/pr-is-product-layer.svg
+++ b/public/assets/images/posts/pull-requests-are-not-git/pr-is-product-layer.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+<title>Pull requests are not Git</title>
+<desc>A pull request combines Git primitives with review metadata, comments, checks, and permissions.</desc>
+<rect width="1200" height="630" fill="#0f172a"/>
+<rect x="70" y="70" width="1060" height="490" rx="28" fill="#111827" stroke="#334155" stroke-width="2"/>
+<text x="95" y="125" class="label">Pull requests are not Git</text>
+<rect x="125" y="210" width="360" height="255" rx="20" class="box"/>
+<text x="165" y="265" class="label">Git gives you</text>
+<text x="165" y="315" class="small">branches</text>
+<text x="165" y="355" class="small">diffs</text>
+<text x="165" y="395" class="small">merges</text>
+<rect x="705" y="185" width="370" height="305" rx="20" class="good"/>
+<text x="750" y="245" class="label">PR adds</text>
+<text x="750" y="295" class="small">conversation</text>
+<text x="750" y="335" class="small">review state</text>
+<text x="750" y="375" class="small">checks</text>
+<text x="750" y="415" class="small">merge policy</text>
+<path d="M505 335 H680" class="line"/>
+<text x="525" y="310" class="small">product layer</text>
+<style>
+.label { font: 700 30px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #e5e7eb; }
+.small { font: 500 22px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #94a3b8; }
+.tiny { font: 500 18px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #64748b; }
+.box { fill: #1e293b; stroke: #475569; stroke-width: 2; }
+.good { fill: #064e3b; stroke: #10b981; stroke-width: 2; }
+.warn { fill: #422006; stroke: #f59e0b; stroke-width: 2; }
+.bad { fill: #450a0a; stroke: #ef4444; stroke-width: 2; }
+.line { stroke: #38bdf8; stroke-width: 5; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+.dimline { stroke: #475569; stroke-width: 3; fill: none; stroke-linecap: round; }
+</style>
+</svg>

--- a/public/assets/images/posts/the-server-gets-a-vote/server-gets-a-vote.svg
+++ b/public/assets/images/posts/the-server-gets-a-vote/server-gets-a-vote.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+<title>The server gets a vote</title>
+<desc>A Git push enters a server side hook that can accept or reject the update.</desc>
+<rect width="1200" height="630" fill="#0f172a"/>
+<rect x="70" y="70" width="1060" height="490" rx="28" fill="#111827" stroke="#334155" stroke-width="2"/>
+<text x="95" y="125" class="label">The server gets a vote</text>
+<rect x="120" y="260" width="190" height="105" rx="18" class="box"/>
+<text x="163" y="325" class="label">push</text>
+<path d="M330 312 H500" class="line"/>
+<rect x="530" y="230" width="210" height="165" rx="18" class="warn"/>
+<text x="575" y="295" class="label">hook</text>
+<text x="568" y="334" class="small">pre-receive</text>
+<path d="M760 285 H990" class="line"/>
+<path d="M760 348 H990" class="dimline"/>
+<rect x="1010" y="235" width="95" height="75" rx="14" class="good"/>
+<text x="1027" y="282" class="small">accept</text>
+<rect x="1010" y="325" width="95" height="75" rx="14" class="bad"/>
+<text x="1027" y="372" class="small">reject</text>
+<style>
+.label { font: 700 30px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #e5e7eb; }
+.small { font: 500 22px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #94a3b8; }
+.tiny { font: 500 18px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #64748b; }
+.box { fill: #1e293b; stroke: #475569; stroke-width: 2; }
+.good { fill: #064e3b; stroke: #10b981; stroke-width: 2; }
+.warn { fill: #422006; stroke: #f59e0b; stroke-width: 2; }
+.bad { fill: #450a0a; stroke: #ef4444; stroke-width: 2; }
+.line { stroke: #38bdf8; stroke-width: 5; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+.dimline { stroke: #475569; stroke-width: 3; fill: none; stroke-linecap: round; }
+</style>
+</svg>

--- a/public/assets/images/posts/what-github-really-sells/github-layers.svg
+++ b/public/assets/images/posts/what-github-really-sells/github-layers.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+<title>What GitHub really sells</title>
+<desc>GitHub is a stack of product layers around the Git object database.</desc>
+<rect width="1200" height="630" fill="#0f172a"/>
+<rect x="70" y="70" width="1060" height="490" rx="28" fill="#111827" stroke="#334155" stroke-width="2"/>
+<text x="95" y="125" class="label">What GitHub really sells</text>
+<rect x="250" y="430" width="700" height="58" rx="12" class="box"/><text x="300" y="468" class="small">Git object database</text>
+<rect x="250" y="365" width="700" height="58" rx="12" class="box"/><text x="300" y="403" class="small">SSH, auth, permissions</text>
+<rect x="250" y="300" width="700" height="58" rx="12" class="warn"/><text x="300" y="338" class="small">rules, hooks, branch protection</text>
+<rect x="250" y="235" width="700" height="58" rx="12" class="good"/><text x="300" y="273" class="small">pull requests, reviews, CI status</text>
+<rect x="250" y="170" width="700" height="58" rx="12" fill="#172554" stroke="#60a5fa" stroke-width="2"/><text x="300" y="208" class="small">search, notifications, UI, APIs</text>
+<style>
+.label { font: 700 30px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #e5e7eb; }
+.small { font: 500 22px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #94a3b8; }
+.tiny { font: 500 18px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #64748b; }
+.box { fill: #1e293b; stroke: #475569; stroke-width: 2; }
+.good { fill: #064e3b; stroke: #10b981; stroke-width: 2; }
+.warn { fill: #422006; stroke: #f59e0b; stroke-width: 2; }
+.bad { fill: #450a0a; stroke: #ef4444; stroke-width: 2; }
+.line { stroke: #38bdf8; stroke-width: 5; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+.dimline { stroke: #475569; stroke-width: 3; fill: none; stroke-linecap: round; }
+</style>
+</svg>

--- a/src/assets/images/posts/git-push-does-not-upload-your-project/push-moves-refs.svg
+++ b/src/assets/images/posts/git-push-does-not-upload-your-project/push-moves-refs.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+<title>Git push moves references</title>
+<desc>A push sends missing Git objects and asks the remote to move a branch reference.</desc>
+<rect width="1200" height="630" fill="#0f172a"/>
+<rect x="70" y="70" width="1060" height="490" rx="28" fill="#111827" stroke="#334155" stroke-width="2"/>
+<text x="95" y="125" class="label">git push does not upload your project</text>
+<rect x="125" y="220" width="330" height="230" rx="20" class="box"/>
+<text x="165" y="270" class="label">local</text>
+<circle cx="205" cy="345" r="24" fill="#38bdf8"/><circle cx="285" cy="345" r="24" fill="#38bdf8"/><circle cx="365" cy="345" r="24" fill="#38bdf8"/>
+<path d="M229 345 H261 M309 345 H341" class="dimline"/>
+<text x="167" y="405" class="small">main -&gt; c3</text>
+<rect x="745" y="220" width="330" height="230" rx="20" class="box"/>
+<text x="785" y="270" class="label">remote</text>
+<circle cx="825" cy="345" r="24" fill="#38bdf8"/><circle cx="905" cy="345" r="24" fill="#38bdf8"/>
+<path d="M849 345 H881" class="dimline"/>
+<text x="787" y="405" class="small">main -&gt; c2</text>
+<path d="M470 335 H720" class="line"/>
+<text x="500" y="306" class="small">send c3, move main</text>
+<style>
+.label { font: 700 30px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #e5e7eb; }
+.small { font: 500 22px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #94a3b8; }
+.tiny { font: 500 18px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #64748b; }
+.box { fill: #1e293b; stroke: #475569; stroke-width: 2; }
+.good { fill: #064e3b; stroke: #10b981; stroke-width: 2; }
+.warn { fill: #422006; stroke: #f59e0b; stroke-width: 2; }
+.bad { fill: #450a0a; stroke: #ef4444; stroke-width: 2; }
+.line { stroke: #38bdf8; stroke-width: 5; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+.dimline { stroke: #475569; stroke-width: 3; fill: none; stroke-linecap: round; }
+</style>
+</svg>

--- a/src/assets/images/posts/github-is-just-a-remote-until-it-isnt/tiny-git-remote.svg
+++ b/src/assets/images/posts/github-is-just-a-remote-until-it-isnt/tiny-git-remote.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+<title>A tiny Git remote over SSH</title>
+<desc>A laptop connects over SSH to a Linux box that stores a bare Git repository.</desc>
+<rect width="1200" height="630" fill="#0f172a"/>
+<rect x="70" y="70" width="1060" height="490" rx="28" fill="#111827" stroke="#334155" stroke-width="2"/>
+<text x="95" y="125" class="label">GitHub is just a remote until it isn't</text>
+<rect x="120" y="250" width="230" height="130" rx="18" class="box"/>
+<text x="160" y="305" class="label">laptop</text>
+<text x="150" y="342" class="small">working tree</text>
+<path d="M370 315 H575" class="line"/>
+<text x="410" y="292" class="small">ssh + git push</text>
+<rect x="605" y="220" width="230" height="190" rx="18" class="box"/>
+<text x="650" y="280" class="label">linux box</text>
+<rect x="665" y="315" width="110" height="55" rx="10" class="good"/>
+<text x="690" y="350" class="small">repo.git</text>
+<path d="M850 315 H1035" class="dimline"/>
+<text x="880" y="292" class="small">no website yet</text>
+<style>
+.label { font: 700 30px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #e5e7eb; }
+.small { font: 500 22px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #94a3b8; }
+.tiny { font: 500 18px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #64748b; }
+.box { fill: #1e293b; stroke: #475569; stroke-width: 2; }
+.good { fill: #064e3b; stroke: #10b981; stroke-width: 2; }
+.warn { fill: #422006; stroke: #f59e0b; stroke-width: 2; }
+.bad { fill: #450a0a; stroke: #ef4444; stroke-width: 2; }
+.line { stroke: #38bdf8; stroke-width: 5; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+.dimline { stroke: #475569; stroke-width: 3; fill: none; stroke-linecap: round; }
+</style>
+</svg>

--- a/src/assets/images/posts/pull-requests-are-not-git/pr-is-product-layer.svg
+++ b/src/assets/images/posts/pull-requests-are-not-git/pr-is-product-layer.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+<title>Pull requests are not Git</title>
+<desc>A pull request combines Git primitives with review metadata, comments, checks, and permissions.</desc>
+<rect width="1200" height="630" fill="#0f172a"/>
+<rect x="70" y="70" width="1060" height="490" rx="28" fill="#111827" stroke="#334155" stroke-width="2"/>
+<text x="95" y="125" class="label">Pull requests are not Git</text>
+<rect x="125" y="210" width="360" height="255" rx="20" class="box"/>
+<text x="165" y="265" class="label">Git gives you</text>
+<text x="165" y="315" class="small">branches</text>
+<text x="165" y="355" class="small">diffs</text>
+<text x="165" y="395" class="small">merges</text>
+<rect x="705" y="185" width="370" height="305" rx="20" class="good"/>
+<text x="750" y="245" class="label">PR adds</text>
+<text x="750" y="295" class="small">conversation</text>
+<text x="750" y="335" class="small">review state</text>
+<text x="750" y="375" class="small">checks</text>
+<text x="750" y="415" class="small">merge policy</text>
+<path d="M505 335 H680" class="line"/>
+<text x="525" y="310" class="small">product layer</text>
+<style>
+.label { font: 700 30px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #e5e7eb; }
+.small { font: 500 22px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #94a3b8; }
+.tiny { font: 500 18px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #64748b; }
+.box { fill: #1e293b; stroke: #475569; stroke-width: 2; }
+.good { fill: #064e3b; stroke: #10b981; stroke-width: 2; }
+.warn { fill: #422006; stroke: #f59e0b; stroke-width: 2; }
+.bad { fill: #450a0a; stroke: #ef4444; stroke-width: 2; }
+.line { stroke: #38bdf8; stroke-width: 5; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+.dimline { stroke: #475569; stroke-width: 3; fill: none; stroke-linecap: round; }
+</style>
+</svg>

--- a/src/assets/images/posts/the-server-gets-a-vote/server-gets-a-vote.svg
+++ b/src/assets/images/posts/the-server-gets-a-vote/server-gets-a-vote.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+<title>The server gets a vote</title>
+<desc>A Git push enters a server side hook that can accept or reject the update.</desc>
+<rect width="1200" height="630" fill="#0f172a"/>
+<rect x="70" y="70" width="1060" height="490" rx="28" fill="#111827" stroke="#334155" stroke-width="2"/>
+<text x="95" y="125" class="label">The server gets a vote</text>
+<rect x="120" y="260" width="190" height="105" rx="18" class="box"/>
+<text x="163" y="325" class="label">push</text>
+<path d="M330 312 H500" class="line"/>
+<rect x="530" y="230" width="210" height="165" rx="18" class="warn"/>
+<text x="575" y="295" class="label">hook</text>
+<text x="568" y="334" class="small">pre-receive</text>
+<path d="M760 285 H990" class="line"/>
+<path d="M760 348 H990" class="dimline"/>
+<rect x="1010" y="235" width="95" height="75" rx="14" class="good"/>
+<text x="1027" y="282" class="small">accept</text>
+<rect x="1010" y="325" width="95" height="75" rx="14" class="bad"/>
+<text x="1027" y="372" class="small">reject</text>
+<style>
+.label { font: 700 30px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #e5e7eb; }
+.small { font: 500 22px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #94a3b8; }
+.tiny { font: 500 18px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #64748b; }
+.box { fill: #1e293b; stroke: #475569; stroke-width: 2; }
+.good { fill: #064e3b; stroke: #10b981; stroke-width: 2; }
+.warn { fill: #422006; stroke: #f59e0b; stroke-width: 2; }
+.bad { fill: #450a0a; stroke: #ef4444; stroke-width: 2; }
+.line { stroke: #38bdf8; stroke-width: 5; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+.dimline { stroke: #475569; stroke-width: 3; fill: none; stroke-linecap: round; }
+</style>
+</svg>

--- a/src/assets/images/posts/what-github-really-sells/github-layers.svg
+++ b/src/assets/images/posts/what-github-really-sells/github-layers.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+<title>What GitHub really sells</title>
+<desc>GitHub is a stack of product layers around the Git object database.</desc>
+<rect width="1200" height="630" fill="#0f172a"/>
+<rect x="70" y="70" width="1060" height="490" rx="28" fill="#111827" stroke="#334155" stroke-width="2"/>
+<text x="95" y="125" class="label">What GitHub really sells</text>
+<rect x="250" y="430" width="700" height="58" rx="12" class="box"/><text x="300" y="468" class="small">Git object database</text>
+<rect x="250" y="365" width="700" height="58" rx="12" class="box"/><text x="300" y="403" class="small">SSH, auth, permissions</text>
+<rect x="250" y="300" width="700" height="58" rx="12" class="warn"/><text x="300" y="338" class="small">rules, hooks, branch protection</text>
+<rect x="250" y="235" width="700" height="58" rx="12" class="good"/><text x="300" y="273" class="small">pull requests, reviews, CI status</text>
+<rect x="250" y="170" width="700" height="58" rx="12" fill="#172554" stroke="#60a5fa" stroke-width="2"/><text x="300" y="208" class="small">search, notifications, UI, APIs</text>
+<style>
+.label { font: 700 30px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #e5e7eb; }
+.small { font: 500 22px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #94a3b8; }
+.tiny { font: 500 18px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #64748b; }
+.box { fill: #1e293b; stroke: #475569; stroke-width: 2; }
+.good { fill: #064e3b; stroke: #10b981; stroke-width: 2; }
+.warn { fill: #422006; stroke: #f59e0b; stroke-width: 2; }
+.bad { fill: #450a0a; stroke: #ef4444; stroke-width: 2; }
+.line { stroke: #38bdf8; stroke-width: 5; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+.dimline { stroke: #475569; stroke-width: 3; fill: none; stroke-linecap: round; }
+</style>
+</svg>

--- a/src/content/blog/250410-github-is-just-a-remote-until-it-isnt.md
+++ b/src/content/blog/250410-github-is-just-a-remote-until-it-isnt.md
@@ -17,7 +17,7 @@ description: "A small GitHub without GitHub: one Linux box, one bare repository,
 ogImage: "/assets/images/posts/github-is-just-a-remote-until-it-isnt/tiny-git-remote.svg"
 ---
 
-_Part 1 of 5 in [Tiny GitHub from first principles](/posts/github-is-just-a-remote-until-it-isnt/)._
+_Part 1 of 5 in [GitHub without the website](/posts/github-is-just-a-remote-until-it-isnt/): rebuilding just enough of GitHub to see where Git stops and the product begins._
 
 Most developers learn Git and GitHub at the same time, which is convenient and a little damaging.
 
@@ -27,7 +27,9 @@ That is not Git.
 
 Git is much smaller and much stranger. GitHub is a product wrapped around it.
 
-I wanted a clean way to feel that boundary again, so I tried the dumbest version possible: no web UI, no issues, no pull requests, no organizations, no Actions. Just a Linux machine reachable over SSH and a bare repository sitting on disk.
+The best way I know to make that boundary obvious is to remove almost everything.
+
+No web UI, no issues, no pull requests, no organizations, no Actions. Just a Linux machine reachable over SSH and a bare repository sitting on disk.
 
 It is not a useful replacement for GitHub. That is not the point.
 
@@ -170,7 +172,7 @@ Above that, there is collaboration: pull requests, comments, review state, notif
 
 Above that, there is product: search, releases, projects, security alerts, APIs, UI.
 
-You do not need to rebuild all of that to understand the first layer. You only need a bare repository and one successful push.
+You do not need to rebuild all of that to understand the first layer. You only need a bare repository, SSH access, and one successful push.
 
 That is enough to make GitHub feel less magical.
 

--- a/src/content/blog/250410-github-is-just-a-remote-until-it-isnt.md
+++ b/src/content/blog/250410-github-is-just-a-remote-until-it-isnt.md
@@ -1,0 +1,175 @@
+---
+author: Romain C.
+pubDatetime: 2025-04-10T10:30:00Z
+title: "GitHub is just a remote until it isn't"
+slug: github-is-just-a-remote-until-it-isnt
+featured: false
+draft: true
+tags: ["git", "github", "ssh", "software-architecture"]
+description: "A small GitHub without GitHub: one Linux box, one bare repository, and the first useful boundary between Git and the product built around it."
+---
+
+Most developers learn Git and GitHub at the same time, which is convenient and a little damaging.
+
+You clone from GitHub. You push to GitHub. You open pull requests on GitHub. After a while, the words start to blur. Git becomes the thing with the green button, the branch selector, the review comments, the checks, the scary red merge conflict banner.
+
+That is not Git.
+
+Git is much smaller and much stranger. GitHub is a product wrapped around it.
+
+I wanted a clean way to feel that boundary again, so I tried the dumbest version possible: no web UI, no issues, no pull requests, no organizations, no Actions. Just a Linux machine reachable over SSH and a bare repository sitting on disk.
+
+It is not a useful replacement for GitHub. That is not the point.
+
+The point is that it explains the first layer.
+
+![A tiny Git remote over SSH](../../assets/images/posts/github-is-just-a-remote-until-it-isnt/tiny-git-remote.svg)
+
+## A remote is not a website
+
+A Git remote is basically a named place where Git can exchange objects and refs.
+
+That place can be GitHub. It can be GitLab. It can be a folder on another machine. It can even be another folder on your own laptop, although that is less dramatic.
+
+When you run this:
+
+```bash
+git remote add origin git@github.com:romain/project.git
+git push origin main
+```
+
+the important part is not the browser. The important part is that `origin` resolves to another Git repository that can receive your branch.
+
+So if we remove GitHub, we need somewhere else for that repository to live.
+
+A small Linux box is enough.
+
+```bash
+ssh git@example.com
+mkdir -p /srv/git/demo.git
+cd /srv/git/demo.git
+git init --bare
+```
+
+The `--bare` flag matters. A normal Git repository has your project files plus a `.git` directory. A bare repository has only the Git database and refs. It does not have a checked-out working tree.
+
+That sounds like a detail until you think about a shared remote.
+
+If several people push to the same machine, which version of the files should be checked out in the working tree? What happens if someone edits files directly on the server? What branch should the server be "on"?
+
+A remote repository should not be editing the project. It should store the history and branch pointers. That is what a bare repo is for.
+
+## The first push
+
+From my laptop, the setup is almost boring:
+
+```bash
+git init demo
+cd demo
+printf "hello\n" > README.md
+git add README.md
+git commit -m "Initial commit"
+git remote add origin git@example.com:/srv/git/demo.git
+git push origin main
+```
+
+At this point, nothing magical happened.
+
+The server did not render a project page. It did not show a commit graph. It did not create a nice profile card. It just received Git objects and updated a ref called `main`.
+
+That is already enough to collaborate.
+
+Someone else can run:
+
+```bash
+git clone git@example.com:/srv/git/demo.git
+```
+
+They get the repository. They can commit. They can push. If we both push incompatible histories, Git will complain in the same annoying way it does with GitHub.
+
+We have recreated the oldest and most boring part of GitHub: shared Git hosting.
+
+Boring is not an insult here. Boring infrastructure is often the part you actually rely on.
+
+## Identity appears before product
+
+Even in this tiny version, identity shows up quickly.
+
+If everyone connects as the same Unix user, the server can tell that someone pushed, but not really who. The SSH key may identify the person at the SSH layer, but the filesystem sees the same account.
+
+That is fine for a toy repo. It is not fine for a company.
+
+GitHub's login model, SSH keys, deploy keys, organizations, teams, repository permissions, audit logs, and branch rules are all product layers over this basic need: the remote must know who is asking to change history, and whether they are allowed to do it.
+
+The tiny server makes that feel less abstract.
+
+A remote is not just storage. It is a place where trust decisions eventually accumulate.
+
+## What this version can do
+
+This small setup can already handle the basic Git loop:
+
+```bash
+git clone git@example.com:/srv/git/demo.git
+# edit files
+git add .
+git commit -m "Change something"
+git push origin main
+```
+
+It can also handle branches:
+
+```bash
+git checkout -b feature/readme
+git push origin feature/readme
+```
+
+And it can reject non-fast-forward updates if the remote cannot safely move the branch pointer:
+
+```bash
+! [rejected] main -> main (fetch first)
+```
+
+That error is not a GitHub personality trait. It is Git protecting the remote ref from being moved in a way that would drop commits from the visible branch history.
+
+GitHub makes the message nicer. The underlying idea is older.
+
+## What this version cannot do
+
+It cannot show you a pull request.
+
+It cannot store review comments.
+
+It cannot run CI and put a green check next to a commit.
+
+It cannot tell you that a dependency has a CVE. It cannot render Markdown beautifully. It cannot notify your team in Slack. It cannot search every repository in an organization. It cannot tell you who approved a production change three months ago.
+
+Those things are not Git.
+
+They are the reason GitHub is valuable.
+
+That distinction is the whole experiment. If you strip GitHub down to SSH and a bare repository, the Git part is still alive. The collaboration product is gone.
+
+## The useful mental model
+
+I now think of GitHub in layers.
+
+At the bottom, there is Git storage: objects, refs, packfiles, branches.
+
+Above that, there is access: SSH keys, users, permissions.
+
+Above that, there is policy: who can push, what can be merged, which checks must pass.
+
+Above that, there is collaboration: pull requests, comments, review state, notifications.
+
+Above that, there is product: search, releases, projects, security alerts, APIs, UI.
+
+You do not need to rebuild all of that to understand the first layer. You only need a bare repository and one successful push.
+
+That is enough to make GitHub feel less magical.
+
+It also makes the next question more interesting.
+
+If `git push` is not uploading a folder to a website, what is it actually doing?
+
+[Next: `git push` does not upload your project](/posts/git-push-does-not-upload-your-project/)

--- a/src/content/blog/250410-github-is-just-a-remote-until-it-isnt.md
+++ b/src/content/blog/250410-github-is-just-a-remote-until-it-isnt.md
@@ -4,10 +4,20 @@ pubDatetime: 2025-04-10T10:30:00Z
 title: "GitHub is just a remote until it isn't"
 slug: github-is-just-a-remote-until-it-isnt
 featured: false
-draft: true
-tags: ["git", "github", "ssh", "software-architecture"]
+draft: false
+tags:
+  [
+    "git",
+    "github",
+    "ssh",
+    "software-engineering",
+    "github-from-first-principles",
+  ]
 description: "A small GitHub without GitHub: one Linux box, one bare repository, and the first useful boundary between Git and the product built around it."
+ogImage: "/assets/images/posts/github-is-just-a-remote-until-it-isnt/tiny-git-remote.svg"
 ---
+
+_Part 1 of 5 in [Tiny GitHub from first principles](/posts/github-is-just-a-remote-until-it-isnt/)._
 
 Most developers learn Git and GitHub at the same time, which is convenient and a little damaging.
 
@@ -46,8 +56,8 @@ A small Linux box is enough.
 
 ```bash
 ssh git@example.com
-mkdir -p /srv/git/demo.git
-cd /srv/git/demo.git
+mkdir -p demo.git
+cd demo.git
 git init --bare
 ```
 
@@ -69,7 +79,7 @@ cd demo
 printf "hello\n" > README.md
 git add README.md
 git commit -m "Initial commit"
-git remote add origin git@example.com:/srv/git/demo.git
+git remote add origin git@example.com:demo.git
 git push origin main
 ```
 
@@ -82,7 +92,7 @@ That is already enough to collaborate.
 Someone else can run:
 
 ```bash
-git clone git@example.com:/srv/git/demo.git
+git clone git@example.com:demo.git
 ```
 
 They get the repository. They can commit. They can push. If we both push incompatible histories, Git will complain in the same annoying way it does with GitHub.
@@ -110,7 +120,7 @@ A remote is not just storage. It is a place where trust decisions eventually acc
 This small setup can already handle the basic Git loop:
 
 ```bash
-git clone git@example.com:/srv/git/demo.git
+git clone git@example.com:demo.git
 # edit files
 git add .
 git commit -m "Change something"
@@ -136,13 +146,9 @@ GitHub makes the message nicer. The underlying idea is older.
 
 ## What this version cannot do
 
-It cannot show you a pull request.
+It cannot show you a pull request, store review comments, or run CI and put a green check next to a commit.
 
-It cannot store review comments.
-
-It cannot run CI and put a green check next to a commit.
-
-It cannot tell you that a dependency has a CVE. It cannot render Markdown beautifully. It cannot notify your team in Slack. It cannot search every repository in an organization. It cannot tell you who approved a production change three months ago.
+It cannot tell you that a dependency has a CVE. It cannot search every repository in an organization. It cannot tell you who approved a production change three months ago.
 
 Those things are not Git.
 

--- a/src/content/blog/250612-git-push-does-not-upload-your-project.md
+++ b/src/content/blog/250612-git-push-does-not-upload-your-project.md
@@ -4,10 +4,20 @@ pubDatetime: 2025-06-12T09:45:00Z
 title: "git push does not upload your project"
 slug: git-push-does-not-upload-your-project
 featured: false
-draft: true
-tags: ["git", "github", "internals", "software-engineering"]
+draft: false
+tags:
+  [
+    "git",
+    "github",
+    "internals",
+    "software-engineering",
+    "github-from-first-principles",
+  ]
 description: "A push is not a folder upload. It is Git sending missing objects and asking the remote to move a branch reference."
+ogImage: "/assets/images/posts/git-push-does-not-upload-your-project/push-moves-refs.svg"
 ---
+
+_Part 2 of 5 in [Tiny GitHub from first principles](/posts/github-is-just-a-remote-until-it-isnt/)._
 
 The first misleading thing about `git push` is the verb.
 

--- a/src/content/blog/250612-git-push-does-not-upload-your-project.md
+++ b/src/content/blog/250612-git-push-does-not-upload-your-project.md
@@ -1,0 +1,236 @@
+---
+author: Romain C.
+pubDatetime: 2025-06-12T09:45:00Z
+title: "git push does not upload your project"
+slug: git-push-does-not-upload-your-project
+featured: false
+draft: true
+tags: ["git", "github", "internals", "software-engineering"]
+description: "A push is not a folder upload. It is Git sending missing objects and asking the remote to move a branch reference."
+---
+
+The first misleading thing about `git push` is the verb.
+
+"Push" sounds like uploading your project to a server. That is close enough for daily work, but it hides the part that explains most Git errors.
+
+Git does not think in project folders. Git thinks in objects and references.
+
+When you push, Git sends the objects the remote is missing, then asks the remote to move a ref. Usually that ref is a branch name like `main`.
+
+That is the whole operation in one sentence. It is also why Git can be both elegant and incredibly rude.
+
+![Git push moves a ref](../../assets/images/posts/git-push-does-not-upload-your-project/push-moves-refs.svg)
+
+## The files are not the unit
+
+Imagine a tiny repository with one file:
+
+```bash
+printf "hello\n" > README.md
+git add README.md
+git commit -m "Initial commit"
+```
+
+Git does not store "the project" as a zip file. It stores content-addressed objects.
+
+A simplified version looks like this:
+
+```text
+commit c1
+  tree t1
+    README.md -> blob b1
+```
+
+The blob contains the file content. The tree says which filenames point to which blobs. The commit points to a tree and records metadata: author, message, parent commits.
+
+Change the file and commit again:
+
+```bash
+printf "hello again\n" > README.md
+git add README.md
+git commit -m "Update readme"
+```
+
+Now the second commit points to a new tree and has the first commit as its parent.
+
+```text
+commit c2
+  parent c1
+  tree t2
+    README.md -> blob b2
+```
+
+This is the part worth keeping in your head: a branch is not a folder. A branch is a name pointing at a commit.
+
+`main` might point at `c2`.
+
+```text
+main -> c2
+```
+
+The commit points backward through history. The branch name points at the tip.
+
+## The remote also has refs
+
+Our tiny GitHub from the previous article is just a bare repository on a server.
+
+It also has objects. It also has refs.
+
+Before your push, the remote might only know about `c1`:
+
+```text
+remote main -> c1
+```
+
+Your laptop knows about `c2`:
+
+```text
+local main -> c2
+```
+
+When you run:
+
+```bash
+git push origin main
+```
+
+Git figures out that the remote is missing `c2` and any objects needed by `c2`. Then it sends those objects. Then it asks the remote to update its `main` ref from `c1` to `c2`.
+
+If `c2` descends from `c1`, the remote can move the pointer forward safely.
+
+That is a fast-forward push.
+
+```text
+before: main -> c1
+after:  main -> c2
+```
+
+No drama. No conflict. The remote moves the label.
+
+## Why pushes get rejected
+
+Now imagine someone else pushed first.
+
+Your laptop thinks the world looks like this:
+
+```text
+c1 -> c2
+main -> c2
+```
+
+The remote has moved on:
+
+```text
+c1 -> c3
+main -> c3
+```
+
+Your `c2` and their `c3` are siblings. Neither contains the other.
+
+If the remote accepted your push and moved `main` from `c3` to `c2`, commit `c3` would disappear from the branch history. It would still exist as an object for a while, but the branch would no longer point to it.
+
+So Git says no.
+
+```text
+! [rejected] main -> main (fetch first)
+```
+
+That message is annoying because it shows up when you just wanted to go home. But it is doing the right thing.
+
+The server is saying: "I cannot move this branch pointer to your commit without losing the commit I already have. Fetch first, reconcile history, then ask again."
+
+That is much clearer than "GitHub rejected my code."
+
+GitHub is not judging your code here. The ref update is not safe.
+
+## Force push is a pointer rewrite
+
+`git push --force` sounds violent because it is.
+
+It tells the remote to move the branch ref even if the move is not a fast-forward.
+
+```bash
+git push --force origin main
+```
+
+That does not delete every old object immediately. Git is more boring than that. But it does change what the branch name means.
+
+Before:
+
+```text
+main -> c3
+```
+
+After:
+
+```text
+main -> c2
+```
+
+Anyone who pulled `c3` now has a history that disagrees with the server. Anyone who based work on `c3` has a mess to untangle.
+
+This is why force pushing to a shared branch feels dangerous. It is not because GitHub has a moral opinion about `--force`. It is because a branch is a shared pointer, and you just moved it somewhere unexpected.
+
+`--force-with-lease` is a better habit because it adds one important check: "only force push if the remote is still where I think it is."
+
+```bash
+git push --force-with-lease origin main
+```
+
+That small lease protects you from overwriting someone else's new work by accident.
+
+## GitHub's UI is mostly explaining refs
+
+A surprising amount of GitHub's interface is just a friendly wrapper around this model.
+
+The branch selector shows refs.
+
+The commit page shows objects.
+
+The compare view shows two commit tips and the diff between their reachable trees.
+
+The "This branch is X commits ahead" message is graph math.
+
+The merge button tries to create a new commit or fast-forward a ref, depending on the merge method.
+
+The scary red warning on a protected branch is policy around a ref update.
+
+Once you see branches as movable names, the UI becomes less mysterious.
+
+## The tiny remote can already say no
+
+Our SSH bare repo has no web UI, but it already has the core mechanics.
+
+If two people push incompatible updates to the same branch, the second push is rejected. If someone force pushes, the branch pointer moves. If someone creates a new branch, the server stores another ref.
+
+You can inspect the bare repo directly:
+
+```bash
+ssh git@example.com
+cd /srv/git/demo.git
+git show-ref
+```
+
+You might see:
+
+```text
+f3a1... refs/heads/main
+9b27... refs/heads/feature/readme
+```
+
+That is the remote's view of the world.
+
+Not files. Not folders. Refs pointing at commits.
+
+## The part GitHub adds next
+
+So far, the remote is mostly passive. It receives objects, checks whether the ref update is safe, and stores the result.
+
+But a remote can do more than accept storage operations.
+
+It can run code before accepting a push. It can reject direct pushes to `main`. It can require commit messages to match a pattern. It can block large files. It can trigger CI.
+
+The moment the server gets to make policy decisions, the tiny GitHub starts to look like a platform.
+
+[Previous: GitHub is just a remote until it isn't](/posts/github-is-just-a-remote-until-it-isnt/)  
+[Next: The server gets a vote](/posts/the-server-gets-a-vote/)

--- a/src/content/blog/250612-git-push-does-not-upload-your-project.md
+++ b/src/content/blog/250612-git-push-does-not-upload-your-project.md
@@ -17,11 +17,13 @@ description: "A push is not a folder upload. It is Git sending missing objects a
 ogImage: "/assets/images/posts/git-push-does-not-upload-your-project/push-moves-refs.svg"
 ---
 
-_Part 2 of 5 in [Tiny GitHub from first principles](/posts/github-is-just-a-remote-until-it-isnt/)._
+_Part 2 of 5 in [GitHub without the website](/posts/github-is-just-a-remote-until-it-isnt/): rebuilding just enough of GitHub to see where Git stops and the product begins._
 
 The first misleading thing about `git push` is the verb.
 
 "Push" sounds like uploading your project to a server. That is close enough for daily work, but it hides the part that explains most Git errors.
+
+The important part is not the upload. The important part is the negotiation.
 
 Git does not think in project folders. Git thinks in objects and references.
 
@@ -240,7 +242,7 @@ But a remote can do more than accept storage operations.
 
 It can run code before accepting a push. It can reject direct pushes to `main`. It can require commit messages to match a pattern. It can block large files. It can trigger CI.
 
-The moment the server gets to make policy decisions, the tiny GitHub starts to look like a platform.
+The moment the server gets to make policy decisions, the tiny GitHub stops being a passive remote and starts to look like a platform.
 
 [Previous: GitHub is just a remote until it isn't](/posts/github-is-just-a-remote-until-it-isnt/)  
 [Next: The server gets a vote](/posts/the-server-gets-a-vote/)

--- a/src/content/blog/250918-the-server-gets-a-vote.md
+++ b/src/content/blog/250918-the-server-gets-a-vote.md
@@ -4,10 +4,20 @@ pubDatetime: 2025-09-18T16:20:00Z
 title: "The server gets a vote"
 slug: the-server-gets-a-vote
 featured: false
-draft: true
-tags: ["git", "github", "devops", "software-engineering"]
+draft: false
+tags:
+  [
+    "git",
+    "github",
+    "devops",
+    "software-engineering",
+    "github-from-first-principles",
+  ]
 description: "Server-side hooks turn a dumb Git remote into something that can enforce policy before history changes."
+ogImage: "/assets/images/posts/the-server-gets-a-vote/server-gets-a-vote.svg"
 ---
+
+_Part 3 of 5 in [Tiny GitHub from first principles](/posts/github-is-just-a-remote-until-it-isnt/)._
 
 A bare Git repository over SSH is already useful, but it is still a little too trusting.
 
@@ -121,13 +131,15 @@ while read oldrev newrev refname; do
 done
 ```
 
-Or block obvious secrets:
+Or block obvious secrets inside the same loop:
 
 ```bash
-git grep -n "AWS_SECRET_ACCESS_KEY" "$newrev" -- . && {
-  echo "Possible secret detected."
-  exit 1
-}
+while read oldrev newrev refname; do
+  if git grep -n "AWS_SECRET_ACCESS_KEY" "$newrev"; then
+    echo "Possible secret detected."
+    exit 1
+  fi
+done
 ```
 
 This is not a full security scanner. Please do not build your compliance program out of a blog post shell script.

--- a/src/content/blog/250918-the-server-gets-a-vote.md
+++ b/src/content/blog/250918-the-server-gets-a-vote.md
@@ -17,7 +17,7 @@ description: "Server-side hooks turn a dumb Git remote into something that can e
 ogImage: "/assets/images/posts/the-server-gets-a-vote/server-gets-a-vote.svg"
 ---
 
-_Part 3 of 5 in [Tiny GitHub from first principles](/posts/github-is-just-a-remote-until-it-isnt/)._
+_Part 3 of 5 in [GitHub without the website](/posts/github-is-just-a-remote-until-it-isnt/): rebuilding just enough of GitHub to see where Git stops and the product begins._
 
 A bare Git repository over SSH is already useful, but it is still a little too trusting.
 
@@ -27,7 +27,7 @@ Sooner or later, someone pushes directly to `main`. Someone commits a secret. So
 
 This is where the remote stops being storage and starts having opinions.
 
-Git has had the primitive for years: hooks.
+The primitive is old and unglamorous: hooks.
 
 ![Server-side hook deciding a push](../../assets/images/posts/the-server-gets-a-vote/server-gets-a-vote.svg)
 
@@ -200,7 +200,7 @@ Then it validates code.
 
 Then it reacts to code.
 
-After that, it is hard to stay small.
+After that, staying small is a choice you have to keep making.
 
 ## The missing social object
 
@@ -210,9 +210,7 @@ But what happens after the branch exists?
 
 Git knows how to compare branches. Git knows how to merge. Git knows how to apply patches. It does not know how to host a conversation, request a review, record an approval, or put a big green button in front of a maintainer.
 
-That object is not Git.
-
-It is the pull request.
+That object is the pull request. It is the place where a branch stops being only a branch and becomes a proposed change.
 
 [Previous: `git push` does not upload your project](/posts/git-push-does-not-upload-your-project/)  
 [Next: Pull requests are not Git](/posts/pull-requests-are-not-git/)

--- a/src/content/blog/250918-the-server-gets-a-vote.md
+++ b/src/content/blog/250918-the-server-gets-a-vote.md
@@ -1,0 +1,206 @@
+---
+author: Romain C.
+pubDatetime: 2025-09-18T16:20:00Z
+title: "The server gets a vote"
+slug: the-server-gets-a-vote
+featured: false
+draft: true
+tags: ["git", "github", "devops", "software-engineering"]
+description: "Server-side hooks turn a dumb Git remote into something that can enforce policy before history changes."
+---
+
+A bare Git repository over SSH is already useful, but it is still a little too trusting.
+
+If you can connect and your push is a valid ref update, the server mostly accepts it. That is fine for a personal repo. It is not enough for a team.
+
+Sooner or later, someone pushes directly to `main`. Someone commits a secret. Someone bypasses tests because the change is "tiny". Someone rewrites history and swears they only touched their own branch.
+
+This is where the remote stops being storage and starts having opinions.
+
+Git has had the primitive for years: hooks.
+
+![Server-side hook deciding a push](../../assets/images/posts/the-server-gets-a-vote/server-gets-a-vote.svg)
+
+## Hooks are where policy enters
+
+A hook is a script Git runs at a specific point in its workflow.
+
+Client-side hooks run on your machine. They can format code before a commit or block a bad commit message. They are useful, but they are not authority. A developer can skip them, forget to install them, or have a slightly different setup.
+
+Server-side hooks run on the remote.
+
+That matters.
+
+If the server-side hook rejects a push, the branch does not move. The policy is enforced at the point where shared history changes.
+
+In a bare repository, hooks live here:
+
+```text
+/srv/git/demo.git/hooks/
+```
+
+Git even creates samples:
+
+```text
+pre-receive.sample
+update.sample
+post-receive.sample
+```
+
+The names are not decorative.
+
+`pre-receive` runs before refs are updated. It can reject the entire push.
+
+`update` runs once per ref being updated. It can reject one branch update.
+
+`post-receive` runs after refs are updated. It is useful for notifications or deployment triggers, but it is too late to block the push.
+
+## Blocking direct pushes to main
+
+The simplest useful hook is branch protection.
+
+GitHub has a nice UI for this. Our tiny GitHub has a shell script.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+while read oldrev newrev refname; do
+  if [ "$refname" = "refs/heads/main" ]; then
+    echo "Direct pushes to main are not allowed."
+    echo "Push a branch and merge it after review."
+    exit 1
+  fi
+done
+```
+
+Save that as:
+
+```text
+/srv/git/demo.git/hooks/pre-receive
+```
+
+Then make it executable:
+
+```bash
+chmod +x /srv/git/demo.git/hooks/pre-receive
+```
+
+Now a direct push to `main` fails.
+
+```text
+remote: Direct pushes to main are not allowed.
+remote: Push a branch and merge it after review.
+! [remote rejected] main -> main (pre-receive hook declined)
+```
+
+This is crude, but the idea is not crude at all.
+
+The remote is now an authority. It can say: "Even if this is a valid Git update, I will not accept it."
+
+That sentence is basically the beginning of branch protection.
+
+## Checks before history changes
+
+A hook can inspect the commits being introduced.
+
+For example, reject commits with suspicious messages:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+while read oldrev newrev refname; do
+  for commit in $(git rev-list "$oldrev".."$newrev"); do
+    subject=$(git log -1 --pretty=%s "$commit")
+    if [[ "$subject" == *"WIP"* ]]; then
+      echo "Commit $commit contains WIP in the subject."
+      exit 1
+    fi
+  done
+done
+```
+
+Or block obvious secrets:
+
+```bash
+git grep -n "AWS_SECRET_ACCESS_KEY" "$newrev" -- . && {
+  echo "Possible secret detected."
+  exit 1
+}
+```
+
+This is not a full security scanner. Please do not build your compliance program out of a blog post shell script.
+
+But it shows the shape of the thing.
+
+GitHub's protected branches, required checks, secret scanning, and rulesets are polished product versions of a simple idea: before the shared ref moves, the server can run policy.
+
+## Why server-side is different
+
+Client-side checks are about convenience.
+
+Server-side checks are about trust.
+
+A formatter hook on my laptop helps me avoid dirty commits. A pre-receive hook on the server protects everyone else from my bad day.
+
+That difference is important in teams. The shared repository is not just a backup location. It is a coordination point. It decides what counts as accepted history.
+
+This is also why "but the tests passed locally" is not enough in serious workflows.
+
+The local machine is not the source of truth. The remote is.
+
+## The hook is also a terrible product
+
+Our hook works, but it is miserable compared to GitHub.
+
+Changing the policy requires SSH access to the server. The error messages are whatever the shell script prints. There is no UI to explain which rule failed. There is no audit trail. There is no per-team permission model. There is no temporary bypass with approval. There is no list of required checks with friendly names.
+
+This is where the product value becomes obvious.
+
+GitHub did not invent the idea that a remote can reject a push. It made that idea usable for normal teams.
+
+A staff engineer can configure a protected branch without editing a shell script in `/srv/git`. A reviewer can see which checks passed. A developer can understand why a merge is blocked without reading Bash.
+
+That is not trivial. It is the boring product work that makes a powerful primitive safe to use at scale.
+
+## Hooks are the bridge to automation
+
+Once the server can run code on push, the next temptation is obvious: run more code.
+
+A `post-receive` hook can deploy a static site:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+worktree=/var/www/demo
+GIT_WORK_TREE="$worktree" git checkout -f main
+```
+
+It can send a webhook. It can enqueue a CI job. It can update a mirror. It can notify a chat room.
+
+This is the same slope that leads from Git hosting to a developer platform.
+
+At first, the remote stores code.
+
+Then it validates code.
+
+Then it reacts to code.
+
+After that, it is hard to stay small.
+
+## The missing social object
+
+With hooks, our tiny GitHub can block direct pushes to `main`. It can force people to push branches instead.
+
+But what happens after the branch exists?
+
+Git knows how to compare branches. Git knows how to merge. Git knows how to apply patches. It does not know how to host a conversation, request a review, record an approval, or put a big green button in front of a maintainer.
+
+That object is not Git.
+
+It is the pull request.
+
+[Previous: `git push` does not upload your project](/posts/git-push-does-not-upload-your-project/)  
+[Next: Pull requests are not Git](/posts/pull-requests-are-not-git/)

--- a/src/content/blog/251120-pull-requests-are-not-git.md
+++ b/src/content/blog/251120-pull-requests-are-not-git.md
@@ -4,10 +4,20 @@ pubDatetime: 2025-11-20T11:15:00Z
 title: "Pull requests are not Git"
 slug: pull-requests-are-not-git
 featured: false
-draft: true
-tags: ["git", "github", "code-review", "software-engineering"]
+draft: false
+tags:
+  [
+    "git",
+    "github",
+    "code-review",
+    "software-engineering",
+    "github-from-first-principles",
+  ]
 description: "Git gives us branches, diffs, patches, and merges. A pull request is the collaboration object GitHub built around them."
+ogImage: "/assets/images/posts/pull-requests-are-not-git/pr-is-product-layer.svg"
 ---
+
+_Part 4 of 5 in [Tiny GitHub from first principles](/posts/github-is-just-a-remote-until-it-isnt/)._
 
 Pull requests feel so normal now that it is easy to forget they are not part of Git.
 

--- a/src/content/blog/251120-pull-requests-are-not-git.md
+++ b/src/content/blog/251120-pull-requests-are-not-git.md
@@ -1,0 +1,194 @@
+---
+author: Romain C.
+pubDatetime: 2025-11-20T11:15:00Z
+title: "Pull requests are not Git"
+slug: pull-requests-are-not-git
+featured: false
+draft: true
+tags: ["git", "github", "code-review", "software-engineering"]
+description: "Git gives us branches, diffs, patches, and merges. A pull request is the collaboration object GitHub built around them."
+---
+
+Pull requests feel so normal now that it is easy to forget they are not part of Git.
+
+Git has commits. Git has branches. Git has diffs. Git has merges. Git has patches. Git can send work by email if you want to feel old or work on the Linux kernel.
+
+But Git does not have a pull request object.
+
+There is no `.git/pull-requests/42`. There is no native Git command that stores review comments, approvals, CI status, merge queues, requested changes, or a little avatar next to a nitpick about naming.
+
+A pull request is a product object built around Git data.
+
+That sounds obvious once stated. It also explains a lot about modern development.
+
+![A pull request as product layer](../../assets/images/posts/pull-requests-are-not-git/pr-is-product-layer.svg)
+
+## What Git already gives us
+
+Suppose I create a branch:
+
+```bash
+git checkout -b feature/tiny-github
+# edit files
+git commit -am "Explain bare remotes"
+git push origin feature/tiny-github
+```
+
+Git now has enough information to compare my branch with `main`.
+
+```bash
+git diff main...feature/tiny-github
+```
+
+It can show commits:
+
+```bash
+git log --oneline main..feature/tiny-github
+```
+
+It can merge:
+
+```bash
+git checkout main
+git merge feature/tiny-github
+```
+
+It can generate a patch:
+
+```bash
+git format-patch main..feature/tiny-github
+```
+
+So, strictly speaking, we do not need GitHub to move code from a branch into `main`.
+
+We need GitHub because the hard part is usually not the merge. It is the coordination around the merge.
+
+## The missing thing is conversation
+
+A pull request gives a branch a room.
+
+That room has a title, a description, reviewers, comments, inline discussions, status checks, labels, permissions, timeline events, and a final decision.
+
+The branch is Git.
+
+The room is GitHub.
+
+This is why a pull request can be closed without merging. The branch still exists. The commits still exist. The conversation ended.
+
+It is also why a pull request can be reopened. Git did not resurrect anything special. The product object changed state.
+
+Once you see the PR as a room around a diff, a lot of GitHub behavior makes more sense.
+
+Review comments are not stored in Git. They are attached to GitHub's model of a file diff at a point in time.
+
+Approvals are not Git. They are review records.
+
+Required checks are not Git. They are status records attached to commits.
+
+The merge button is not Git. It is a controlled way to perform a Git operation after product-level rules pass.
+
+## Rebuilding a terrible pull request by hand
+
+Our tiny GitHub can fake a PR workflow, badly.
+
+Developer pushes a branch:
+
+```bash
+git push origin feature/tiny-github
+```
+
+Reviewer fetches it:
+
+```bash
+git fetch origin feature/tiny-github
+git diff origin/main...origin/feature/tiny-github
+```
+
+Reviewer writes comments in chat, email, or a text file. Developer pushes more commits. Reviewer fetches again. Eventually someone merges:
+
+```bash
+git checkout main
+git merge --no-ff origin/feature/tiny-github
+git push origin main
+```
+
+This works.
+
+It is also awful.
+
+There is no durable review history. No inline comments tied to lines. No easy way to see whether the latest push invalidated a previous approval. No checks integrated into the decision. No merge queue. No audit trail that a future teammate can understand in thirty seconds.
+
+The Git operations are fine. The collaboration layer is missing.
+
+## Git email workflows are a useful contrast
+
+Some projects do not use pull requests the GitHub way.
+
+The Linux kernel famously uses patches over email. A contributor sends a patch series. Maintainers review it. The discussion happens on mailing lists. Eventually a maintainer applies the patches.
+
+That workflow is not primitive. It is just different.
+
+It makes one thing clear: Git does not require GitHub's PR model. The branch plus PR workflow is a product choice, not a law of nature.
+
+Most teams still choose it because it fits the way they work. The PR becomes the shared unit of review. It is small enough to discuss, visible enough to track, and structured enough for automation.
+
+## The PR changed how we design work
+
+This is the part I find more interesting than the mechanics.
+
+Once pull requests become the default unit of collaboration, developers start shaping work to fit them.
+
+We split features into reviewable chunks. We write descriptions for changes that already exist. We add screenshots because the PR template asks for them. We wait for CI because the button is disabled. We ask for approval because the branch rule requires it.
+
+Some of that is good.
+
+Small reviewable changes are usually better than giant surprise merges. CI before merge is usually better than CI after production. A written explanation often catches vague thinking.
+
+Some of it is theater.
+
+A PR can be approved without being understood. A green check can test the wrong thing. A large team can drown in review notifications and call it quality control.
+
+The pull request is a tool, not a moral framework.
+
+But it is a powerful tool because it sits exactly where technical change becomes social change.
+
+## Why this matters for GitHub
+
+If GitHub only hosted Git repositories, it would be useful.
+
+Pull requests made it sticky.
+
+They turned GitHub from a place where code lives into a place where code decisions happen. That is a much stronger position.
+
+The tiny SSH remote can store my branch. It cannot tell the story of why the branch should merge.
+
+A pull request can.
+
+It connects the Git primitives to human workflow:
+
+```text
+branch -> diff -> discussion -> checks -> approval -> merge
+```
+
+Only two parts of that chain are pure Git.
+
+That is the point.
+
+## The merge button is not the center
+
+The merge button gets the attention because it changes the repository. But the value of a PR is often everything before the click.
+
+The discussion that prevents a bad abstraction.
+
+The test failure that catches a broken assumption.
+
+The reviewer who notices the migration path is unsafe.
+
+The short comment that explains why the weird code is intentional.
+
+Those things do not belong in the Git object database. They belong around it.
+
+That is why pull requests are not Git, and why they are still one of the most important parts of GitHub.
+
+[Previous: The server gets a vote](/posts/the-server-gets-a-vote/)  
+[Next: What GitHub really sells](/posts/what-github-really-sells/)

--- a/src/content/blog/251120-pull-requests-are-not-git.md
+++ b/src/content/blog/251120-pull-requests-are-not-git.md
@@ -17,11 +17,13 @@ description: "Git gives us branches, diffs, patches, and merges. A pull request 
 ogImage: "/assets/images/posts/pull-requests-are-not-git/pr-is-product-layer.svg"
 ---
 
-_Part 4 of 5 in [Tiny GitHub from first principles](/posts/github-is-just-a-remote-until-it-isnt/)._
+_Part 4 of 5 in [GitHub without the website](/posts/github-is-just-a-remote-until-it-isnt/): rebuilding just enough of GitHub to see where Git stops and the product begins._
 
 Pull requests feel so normal now that it is easy to forget they are not part of Git.
 
 Git has commits. Git has branches. Git has diffs. Git has merges. Git has patches. Git can send work by email if you want to feel old or work on the Linux kernel.
+
+That is a lot. It is still not a pull request.
 
 But Git does not have a pull request object.
 
@@ -198,7 +200,9 @@ The short comment that explains why the weird code is intentional.
 
 Those things do not belong in the Git object database. They belong around it.
 
-That is why pull requests are not Git, and why they are still one of the most important parts of GitHub.
+That is why pull requests are not Git.
+
+It is also why they are one of the most important parts of GitHub. They give teams a place to decide whether a piece of Git history deserves to become shared history.
 
 [Previous: The server gets a vote](/posts/the-server-gets-a-vote/)  
 [Next: What GitHub really sells](/posts/what-github-really-sells/)

--- a/src/content/blog/260122-what-github-really-sells.md
+++ b/src/content/blog/260122-what-github-really-sells.md
@@ -4,10 +4,20 @@ pubDatetime: 2026-01-22T10:00:00Z
 title: "What GitHub really sells"
 slug: what-github-really-sells
 featured: false
-draft: true
-tags: ["git", "github", "developer-tools", "software-engineering"]
+draft: false
+tags:
+  [
+    "git",
+    "github",
+    "developer-tools",
+    "software-engineering",
+    "github-from-first-principles",
+  ]
 description: "After stripping GitHub down to SSH and a bare repository, the product becomes clearer: GitHub sells the collaboration system around Git."
+ogImage: "/assets/images/posts/what-github-really-sells/github-layers.svg"
 ---
+
+_Part 5 of 5 in [Tiny GitHub from first principles](/posts/github-is-just-a-remote-until-it-isnt/)._
 
 The tiny GitHub experiment starts as a joke and ends as a decent product lesson.
 
@@ -132,27 +142,7 @@ That pattern repeats across GitHub. The primitive is often simple. The product w
 
 ## The boring features are the expensive ones
 
-Search.
-
-Notifications.
-
-Audit logs.
-
-Repository settings.
-
-Team management.
-
-Code owners.
-
-Release pages.
-
-Security advisories.
-
-Dependabot.
-
-APIs.
-
-Status pages.
+Search, notifications, audit logs, repository settings, team management, code owners, release pages, security advisories, Dependabot, APIs, status pages.
 
 None of these make a great conference demo by themselves. Together, they are why organizations stay.
 

--- a/src/content/blog/260122-what-github-really-sells.md
+++ b/src/content/blog/260122-what-github-really-sells.md
@@ -17,15 +17,15 @@ description: "After stripping GitHub down to SSH and a bare repository, the prod
 ogImage: "/assets/images/posts/what-github-really-sells/github-layers.svg"
 ---
 
-_Part 5 of 5 in [Tiny GitHub from first principles](/posts/github-is-just-a-remote-until-it-isnt/)._
+_Part 5 of 5 in [GitHub without the website](/posts/github-is-just-a-remote-until-it-isnt/): rebuilding just enough of GitHub to see where Git stops and the product begins._
 
 The tiny GitHub experiment starts as a joke and ends as a decent product lesson.
 
 Put a bare Git repository on a Linux box. Connect over SSH. Push a branch. Add a hook. Block direct pushes to `main`. Fake a pull request with a diff and a chat thread.
 
-You can get surprisingly far.
+You can get surprisingly far, which is the fun part.
 
-You also hit the wall quickly.
+You also hit the wall quickly, which is the useful part.
 
 That wall is where GitHub lives.
 
@@ -185,10 +185,12 @@ Some GitHub features are just polished wrappers around old Git mechanics. Some a
 
 That is a healthier mental model than treating GitHub as magic or treating Git as the entire story.
 
-Git is the database and protocol at the center.
+Git is the database and protocol at the center. GitHub is the collaboration system around it.
 
-GitHub is the collaboration system around it.
+That distinction sounds academic until something breaks: a rejected push, a blocked merge, a missing approval, a failed check that saves you from yourself.
 
-The difference matters every time a green button decides whether your code becomes shared history.
+Then the boundary matters.
+
+Git can tell you what history is. GitHub helps a team decide what history should become.
 
 [Previous: Pull requests are not Git](/posts/pull-requests-are-not-git/)

--- a/src/content/blog/260122-what-github-really-sells.md
+++ b/src/content/blog/260122-what-github-really-sells.md
@@ -1,0 +1,204 @@
+---
+author: Romain C.
+pubDatetime: 2026-01-22T10:00:00Z
+title: "What GitHub really sells"
+slug: what-github-really-sells
+featured: false
+draft: true
+tags: ["git", "github", "developer-tools", "software-engineering"]
+description: "After stripping GitHub down to SSH and a bare repository, the product becomes clearer: GitHub sells the collaboration system around Git."
+---
+
+The tiny GitHub experiment starts as a joke and ends as a decent product lesson.
+
+Put a bare Git repository on a Linux box. Connect over SSH. Push a branch. Add a hook. Block direct pushes to `main`. Fake a pull request with a diff and a chat thread.
+
+You can get surprisingly far.
+
+You also hit the wall quickly.
+
+That wall is where GitHub lives.
+
+![GitHub product layers around Git](../../assets/images/posts/what-github-really-sells/github-layers.svg)
+
+## Git hosting is the base layer
+
+At the bottom, GitHub stores Git repositories.
+
+That sounds obvious, but it is worth separating from everything else. The repository is the durable core. Objects, refs, branches, tags. Clone and push. Fetch and merge.
+
+Our Linux box can do this.
+
+It can host a bare repository at:
+
+```text
+/srv/git/demo.git
+```
+
+It can accept:
+
+```bash
+git push origin main
+```
+
+It can let someone else clone:
+
+```bash
+git clone git@example.com:/srv/git/demo.git
+```
+
+This base layer matters. If Git hosting is unreliable, nothing above it matters. But the base layer is not enough to explain GitHub's value anymore.
+
+Lots of products can host Git.
+
+GitHub won the social and workflow layers around it.
+
+## Identity and permissions are product, not decoration
+
+The next layer is identity.
+
+Who are you? Which repositories can you read? Which branches can you push? Which secrets can your workflow access? Which organization owns the code? Which team can approve production changes?
+
+A Unix server can answer some of that with users, groups, SSH keys, and filesystem permissions.
+
+It gets ugly fast.
+
+GitHub turns identity into a product surface. SSH keys are attached to accounts. Accounts belong to organizations. Organizations have teams. Teams have repository roles. Repositories have branch rules. Actions have tokens. Audit logs record who changed what.
+
+None of that is glamorous when it works.
+
+It becomes very glamorous the first time you need to remove a contractor's access from twenty repositories at 18:04 on a Friday.
+
+## Rules are where trust becomes visible
+
+A tiny server-side hook can reject a push.
+
+GitHub turns that into rules people can see and manage:
+
+- require a pull request before merging
+- require approvals
+- require status checks
+- block force pushes
+- require signed commits
+- restrict who can push matching branches
+
+The important part is not that GitHub can reject things. A Bash script can reject things.
+
+The important part is that GitHub makes the rules understandable, reviewable, and tied to identities.
+
+A failed rule is visible in the UI. A required check has a name. A bypass can be recorded. A branch can be protected without giving everyone shell access to the remote.
+
+That is the product version of "the server gets a vote."
+
+## Pull requests are the center of gravity
+
+If I had to pick the one object that explains GitHub, I would pick the pull request.
+
+Not the repository. Not the issue. Not Actions.
+
+The pull request.
+
+It is where Git data becomes team decision-making. A branch is proposed. A diff is rendered. Tests attach results. People discuss lines. Reviewers approve or block. The merge button becomes available only when the rules say it can.
+
+The PR is not Git, but it is built close enough to Git that it feels native.
+
+That is the trick.
+
+A good developer tool hides product decisions inside workflows that feel technical. After a few years, the product shape feels inevitable. Of course a change should be a branch plus a PR plus checks plus review. What else would it be?
+
+There are other answers. Email patches. Trunk-based development with pairing. Gerrit-style change reviews. Internal monorepo tools. Direct commits with strong ownership.
+
+GitHub did not discover the only possible workflow.
+
+It popularized one that worked well enough for millions of teams.
+
+## Automation made the repository reactive
+
+GitHub Actions changed the repository from a place where code sits into a place where code triggers work.
+
+Push a commit, run tests.
+
+Open a PR, build a preview.
+
+Create a tag, publish a package.
+
+Change infrastructure code, plan a deployment.
+
+Our tiny Git server can fake this with hooks, but it quickly becomes a maintenance problem. Where do logs live? Who can rerun a failed job? Which secrets are available? Can a fork access them? What environment is the job running in? How do you cancel old runs? How do you debug a flaky test?
+
+The shell script was fun. The platform is useful.
+
+That pattern repeats across GitHub. The primitive is often simple. The product work is making it safe, visible, and repeatable.
+
+## The boring features are the expensive ones
+
+Search.
+
+Notifications.
+
+Audit logs.
+
+Repository settings.
+
+Team management.
+
+Code owners.
+
+Release pages.
+
+Security advisories.
+
+Dependabot.
+
+APIs.
+
+Status pages.
+
+None of these make a great conference demo by themselves. Together, they are why organizations stay.
+
+A developer can host a bare repo in five minutes. A company needs a system that answers boring questions every day:
+
+- Who changed this?
+- Why was this merged?
+- Which check failed?
+- Who approved it?
+- Which release contains the fix?
+- Which repos use the vulnerable package?
+- Which token had access?
+- Which team owns this service?
+
+Git stores history. GitHub stores a lot of the context around history.
+
+That context is the product.
+
+## The tiny version was still worth building
+
+The SSH experiment is not a recommendation to self-host Git with shell scripts.
+
+I would not run a serious team this way unless I had very specific reasons and a high tolerance for boring operational work.
+
+But rebuilding the small core is useful because it removes the fog.
+
+A remote is not a website.
+
+A push is not a folder upload.
+
+A branch is a ref.
+
+A server can reject an update.
+
+A pull request is not Git.
+
+Once those pieces are clear, GitHub becomes easier to understand and easier to criticize fairly.
+
+Some GitHub features are just polished wrappers around old Git mechanics. Some are genuinely hard product layers. Some are workflow choices that feel natural only because we have repeated them for years.
+
+That is a healthier mental model than treating GitHub as magic or treating Git as the entire story.
+
+Git is the database and protocol at the center.
+
+GitHub is the collaboration system around it.
+
+The difference matters every time a green button decides whether your code becomes shared history.
+
+[Previous: Pull requests are not Git](/posts/pull-requests-are-not-git/)


### PR DESCRIPTION
## Summary
- Adds a 5-part article series for the March 2025 to March 2026 gap
- Covers Git remotes, push internals, server-side hooks, pull requests, and GitHub's product layers
- Adds one explanatory SVG diagram per article
- Adds series scaffolding: shared tag, part labels, read-in-order links, and explicit OG images

## Articles
- GitHub is just a remote until it isn't - 2025-04-10
- git push does not upload your project - 2025-06-12
- The server gets a vote - 2025-09-18
- Pull requests are not Git - 2025-11-20
- What GitHub really sells - 2026-01-22

## Review follow-up
- Set all five posts to `draft: false` after review approval
- Added `github-from-first-principles` tag to all five posts
- Normalized article 1 to `software-engineering`
- Added `ogImage` for each article and copied SVGs into `public/assets/images/posts/...`
- Added a stronger series identity: `GitHub without the website`
- Tightened the `It cannot...` passage in part 1
- Switched article 1 examples to idiomatic `git@example.com:demo.git`
- Inlined the `git grep` example into hook scaffolding in part 3
- Compressed the single-word feature list in part 5
- Final polish pass: sharper openings, less metadata-like series line, stronger part 5 ending, and a little more human texture without adding fake anecdotes

## Verification
- ASCII punctuation/privacy scan passed
- Targeted Prettier check passed
- `npm run build` passed with the five posts published
- Rendered smoke check passed for all five generated pages
