### PR TITLE
style: smooth dark page transitions

### DIFF
--- a/public/toggle-theme.js
+++ b/public/toggle-theme.js
@@ -46,8 +46,16 @@ function reflectPreference() {
   }
 }
 
+function reflectPreferenceOnDocument(doc) {
+  doc.documentElement.setAttribute("data-theme", themeValue);
+}
+
 // set early so no page flashes / CSS is made aware
 reflectPreference();
+
+document.addEventListener("astro:before-swap", event => {
+  reflectPreferenceOnDocument(event.newDocument);
+});
 
 window.onload = () => {
   function setThemeFeature() {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -58,6 +58,20 @@ const structuredData = {
 >
   <head>
     <meta charset="UTF-8" />
+    <script is:inline>
+      (() => {
+        const primaryColorScheme = "dark";
+        const storedTheme = localStorage.getItem("theme");
+        const theme =
+          storedTheme ||
+          primaryColorScheme ||
+          (window.matchMedia("(prefers-color-scheme: dark)").matches
+            ? "dark"
+            : "light");
+
+        document.documentElement.setAttribute("data-theme", theme);
+      })();
+    </script>
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
     <link rel="canonical" href={canonicalURL} />
@@ -134,7 +148,7 @@ const structuredData = {
 
     <ClientRouter />
 
-    <script is:inline src="/toggle-theme.js" async></script>
+    <script is:inline src="/toggle-theme.js"></script>
   </head>
   <body>
     <div class="flex min-h-screen flex-col">

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -5,6 +5,10 @@
 @tailwind utilities;
 
 @layer base {
+  html {
+    background-color: rgb(var(--color-fill));
+  }
+
   #sun-svg,
   html[data-theme="dark"] #moon-svg {
     display: none;
@@ -15,6 +19,7 @@
   }
   body {
     @apply flex min-h-[100svh] flex-col bg-skin-fill font-sans text-skin-base selection:bg-skin-accent/10 selection:text-skin-accent;
+    background-color: rgb(var(--color-fill));
     line-height: 1.6;
     letter-spacing: -0.01em;
   }
@@ -128,6 +133,46 @@
     }
     to {
       opacity: 1;
+    }
+  }
+
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation-duration: 160ms;
+    animation-timing-function: ease;
+    background-color: rgb(var(--color-fill));
+  }
+
+  ::view-transition-old(root) {
+    animation-name: page-fade-out;
+  }
+
+  ::view-transition-new(root) {
+    animation-name: page-fade-in;
+  }
+
+  @keyframes page-fade-out {
+    from {
+      opacity: 1;
+    }
+    to {
+      opacity: 0;
+    }
+  }
+
+  @keyframes page-fade-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    ::view-transition-old(root),
+    ::view-transition-new(root) {
+      animation-duration: 1ms;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Prevents the dark-mode white flash by applying `data-theme` before the page can paint
- Removes `async` from the theme script so theme state is not restored late
- Carries the current theme onto Astro's swapped document before view transitions
- Adds explicit root view-transition fade styles with the current theme background

## Verification
- `npx prettier --write src/layouts/Layout.astro src/styles/base.css public/toggle-theme.js --plugin=prettier-plugin-astro`
- `npm run build`
- Rendered-output smoke check verified:
  - early theme script appears before viewport meta
  - theme script is no longer async
  - `astro:before-swap` copies theme to the incoming document
  - built CSS contains themed html background and view-transition rules
