### PR TITLE
fix: clarify article chronology navigation

### DIFF
--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -126,7 +126,7 @@ const nextPost =
           >
             <span class="flex-none">←</span>
             <div>
-              <span>Previous article</span>
+              <span>Newer article</span>
               <div class="text-sm text-skin-accent/85">{prevPost.title}</div>
             </div>
           </a>
@@ -139,7 +139,7 @@ const nextPost =
             class="flex w-full justify-end gap-1 text-right hover:opacity-75 sm:col-start-2"
           >
             <div>
-              <span>Next article</span>
+              <span>Older article</span>
               <div class="text-sm text-skin-accent/85">{nextPost.title}</div>
             </div>
             <span class="flex-none">→</span>

--- a/src/layouts/ProjectDetails.astro
+++ b/src/layouts/ProjectDetails.astro
@@ -179,7 +179,7 @@ const projectMeta = [type, role, status].filter(Boolean);
           >
             <span class="flex-none">←</span>
             <div>
-              <span>Previous project</span>
+              <span>Newer project</span>
               <div class="text-sm text-skin-accent/85">{prevPost.title}</div>
             </div>
           </a>
@@ -192,7 +192,7 @@ const projectMeta = [type, role, status].filter(Boolean);
             class="flex w-full justify-end gap-1 text-right hover:opacity-75 sm:col-start-2"
           >
             <div>
-              <span>Next project</span>
+              <span>Older project</span>
               <div class="text-sm text-skin-accent/85">{nextPost.title}</div>
             </div>
             <span class="flex-none">→</span>


### PR DESCRIPTION
## Summary
- Clarifies chronology navigation labels on both Writing and Work detail pages
- Replaces ambiguous article labels with `Newer article` / `Older article`
- Replaces ambiguous project labels with `Newer project` / `Older project`
- Keeps the existing newest-to-oldest link logic unchanged

## Why
Posts and projects are sorted newest-to-oldest. The old `Previous` / `Next` labels were technically tied to array position, but semantically confusing for readers, especially in multi-part content and Work pages.

## Verification
- `npx prettier --check src/layouts/PostDetails.astro src/layouts/ProjectDetails.astro --plugin=prettier-plugin-astro`
- `npm run build`
- Rendered smoke checks confirm:
  - `Newer article` / `Older article` labels appear on representative posts
  - `Newer project` / `Older project` labels appear on representative Work pages
  - old `Previous article` / `Next article` and `Previous project` / `Next project` labels are gone
