### PR TITLE
fix: hide contact link on mobile nav

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -43,7 +43,7 @@ const { activeNav } = Astro.props;
               Writing
             </a>
           </li>
-          <li>
+          <li class="hidden sm:list-item">
             <a href="mailto:contact@romaincoupey.com">Contact</a>
           </li>
           <li>


### PR DESCRIPTION
## Summary
- Hides the Contact link from the mobile topbar
- Keeps Contact visible on `sm` and wider screens
- Leaves Work, Writing, Search, and theme toggle unchanged on mobile

## Verification
- [x] `npm run format:check`
- [x] `npm run build`
- [x] Rendered HTML/CSS smoke check for `hidden sm:list-item`
- [x] Headless Chromium mobile screenshot OCR: `Romain C. Work Writing`
